### PR TITLE
Update samples for sokol_gfx.h's shader-attributes branch

### DIFF
--- a/d3d11/arraytex-d3d11.c
+++ b/d3d11/arraytex-d3d11.c
@@ -125,6 +125,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* shader to sample from array texture */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "TEXCOORD"
+        },
         .vs.uniform_blocks[0].size = sizeof(params_t),
         .fs.images[0].type=SG_IMAGETYPE_ARRAY,
         .vs.source =
@@ -172,8 +176,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/d3d11/binshader-d3d11.c
+++ b/d3d11/binshader-d3d11.c
@@ -92,19 +92,27 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
-        .vs.uniform_blocks[0].size = sizeof(vs_params_t),
-        .vs.byte_code = vs_bin,
-        .vs.byte_code_size = sizeof(vs_bin),
-        .fs.byte_code = fs_bin,
-        .fs.byte_code_size = sizeof(fs_bin)
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "COLOR"
+        },
+        .vs = {
+            .uniform_blocks[0].size = sizeof(vs_params_t),
+            .byte_code = vs_bin,
+            .byte_code_size = sizeof(vs_bin),
+        },
+        .fs = {
+            .byte_code = fs_bin,
+            .byte_code_size = sizeof(fs_bin)
+        }
     });
 
     /* a pipeline object */
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION", .format = SG_VERTEXFORMAT_FLOAT3 }, 
-                [1] = { .sem_name="COLOR", .format = SG_VERTEXFORMAT_FLOAT4 }
+                [0].format = SG_VERTEXFORMAT_FLOAT3, 
+                [1].format = SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = shd,

--- a/d3d11/blend-d3d11.c
+++ b/d3d11/blend-d3d11.c
@@ -52,6 +52,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* a shader for the fullscreen background quad */
     sg_shader bg_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs[0].sem_name = "POS",
         .vs.source =
             "struct vs_in {\n"
             "  float2 pos: POS;\n"
@@ -82,9 +83,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline bg_pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .buffers[0].stride = 28,
-            .attrs = {
-                [0] = { .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT2 }
-            }
+            .attrs[0].format = SG_VERTEXFORMAT_FLOAT2,
         },
         .shader = bg_shd,
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP,
@@ -92,6 +91,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* a shader for the blended quads */
     sg_shader quad_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POS",
+            [1].sem_name = "COLOR"
+        },
         .vs.uniform_blocks[0].size = sizeof(vs_params_t),
         .vs.source =
             "cbuffer params: register(b0) {\n"
@@ -121,8 +124,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline_desc pip_desc = {
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format = SG_VERTEXFORMAT_FLOAT3,
+                [1].format = SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = quad_shd,

--- a/d3d11/bufferoffsets-d3d11.c
+++ b/d3d11/bufferoffsets-d3d11.c
@@ -56,6 +56,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* a shader to render the 2D shapes */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "COLOR"
+        },
         .vs.source =
             "struct vs_in {\n"
             "  float2 pos: POSITION;\n"
@@ -83,8 +87,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         .index_type = SG_INDEXTYPE_UINT16,
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT2 },
-                [1] = { .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT3 }
+                [0].format=SG_VERTEXFORMAT_FLOAT2,
+                [1].format=SG_VERTEXFORMAT_FLOAT3
             }
         }
     });

--- a/d3d11/cube-d3d11.c
+++ b/d3d11/cube-d3d11.c
@@ -91,25 +91,31 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
-        .vs.uniform_blocks[0].size = sizeof(vs_params_t),
-        .vs.source =
-            "cbuffer params: register(b0) {\n"
-            "  float4x4 mvp;\n"
-            "};\n"
-            "struct vs_in {\n"
-            "  float4 pos: POSITION;\n"
-            "  float4 color: COLOR1;\n"
-            "};\n"
-            "struct vs_out {\n"
-            "  float4 color: COLOR0;\n"
-            "  float4 pos: SV_Position;\n"
-            "};\n"
-            "vs_out main(vs_in inp) {\n"
-            "  vs_out outp;\n"
-            "  outp.pos = mul(mvp, inp.pos);\n"
-            "  outp.color = inp.color;\n"
-            "  return outp;\n"
-            "};\n",
+        .attrs = {
+            [0] = { .sem_name = "POSITION" },
+            [1] = { .sem_name = "COLOR", .sem_index=1 }
+        },
+        .vs = {
+            .uniform_blocks[0].size = sizeof(vs_params_t),
+            .source =
+                "cbuffer params: register(b0) {\n"
+                "  float4x4 mvp;\n"
+                "};\n"
+                "struct vs_in {\n"
+                "  float4 pos: POSITION;\n"
+                "  float4 color: COLOR1;\n"
+                "};\n"
+                "struct vs_out {\n"
+                "  float4 color: COLOR0;\n"
+                "  float4 pos: SV_Position;\n"
+                "};\n"
+                "vs_out main(vs_in inp) {\n"
+                "  vs_out outp;\n"
+                "  outp.pos = mul(mvp, inp.pos);\n"
+                "  outp.color = inp.color;\n"
+                "  return outp;\n"
+                "};\n",
+        },
         .fs.source =
             "float4 main(float4 color: COLOR0): SV_Target0 {\n"
             "  return color;\n"
@@ -122,8 +128,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         .layout = {
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .sem_name="POSITION", .format = SG_VERTEXFORMAT_FLOAT3 }, 
-                [1] = { .sem_name="COLOR", .sem_index=1, .format = SG_VERTEXFORMAT_FLOAT4 }
+                [0].format = SG_VERTEXFORMAT_FLOAT3, 
+                [1].format = SG_VERTEXFORMAT_FLOAT4 
             }
         },
         .shader = shd,

--- a/d3d11/dyntex-d3d11.c
+++ b/d3d11/dyntex-d3d11.c
@@ -112,6 +112,11 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* a shader to render textured cube */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "COLOR",
+            [2].sem_name = "TEXCOORD"
+        },
         .vs.uniform_blocks[0].size = sizeof(vs_params_t),
         .fs.images[0].type=SG_IMAGETYPE_2D,
         .vs.source =
@@ -147,9 +152,9 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION",   .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="COLOR",      .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .sem_name="TEXCOORD",   .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format = SG_VERTEXFORMAT_FLOAT3,
+                [1].format = SG_VERTEXFORMAT_FLOAT4,
+                [2].format = SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/d3d11/imgui-d3d11.cc
+++ b/d3d11/imgui-d3d11.cc
@@ -104,6 +104,9 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_shader_desc shd_desc = { };
     auto& ub = shd_desc.vs.uniform_blocks[0];
     ub.size = sizeof(vs_params_t);
+    shd_desc.attrs[0].sem_name = "POSITION";
+    shd_desc.attrs[1].sem_name = "TEXCOORD";
+    shd_desc.attrs[2].sem_name = "COLOR";
     shd_desc.vs.source =
         "cbuffer params {\n"
         "  float2 disp_size;\n"
@@ -138,9 +141,9 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline_desc pip_desc = { };
     pip_desc.layout.buffers[0].stride = sizeof(ImDrawVert);
     auto& attrs = pip_desc.layout.attrs;
-    attrs[0].sem_name="POSITION"; attrs[0].offset=offsetof(ImDrawVert, pos); attrs[0].format=SG_VERTEXFORMAT_FLOAT2;
-    attrs[1].sem_name="TEXCOORD"; attrs[1].offset=offsetof(ImDrawVert, uv); attrs[1].format=SG_VERTEXFORMAT_FLOAT2;
-    attrs[2].sem_name="COLOR"; attrs[2].offset=offsetof(ImDrawVert, col); attrs[2].format=SG_VERTEXFORMAT_UBYTE4N;
+    attrs[0].offset=offsetof(ImDrawVert, pos); attrs[0].format=SG_VERTEXFORMAT_FLOAT2;
+    attrs[1].offset=offsetof(ImDrawVert, uv); attrs[1].format=SG_VERTEXFORMAT_FLOAT2;
+    attrs[2].offset=offsetof(ImDrawVert, col); attrs[2].format=SG_VERTEXFORMAT_UBYTE4N;
     pip_desc.shader = shd;
     pip_desc.index_type = SG_INDEXTYPE_UINT16;
     pip_desc.blend.enabled = true;

--- a/d3d11/inject-d3d11.c
+++ b/d3d11/inject-d3d11.c
@@ -163,6 +163,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "TEXCOORD"
+        },
         .vs.uniform_blocks[0].size = sizeof(vs_params_t),
         .fs.images[0].type = SG_IMAGETYPE_2D,
         .vs.source =
@@ -195,8 +199,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/d3d11/instancing-d3d11.c
+++ b/d3d11/instancing-d3d11.c
@@ -75,6 +75,11 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "COLOR",
+            [2].sem_name = "INSTPOS"
+        },
         .vs.uniform_blocks[0].size = sizeof(vs_params_t),
         .vs.source = 
             "cbuffer params: register(b0) {\n"
@@ -113,9 +118,9 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
                 [1] = { .stride = 12, .step_func = SG_VERTEXSTEP_PER_INSTANCE }
             },
             .attrs = {
-                [0] = { .sem_name="POSITION", .offset=0,  .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
-                [1] = { .sem_name="COLOR",    .offset=12, .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
-                [2] = { .sem_name="INSTPOS",  .offset=0,  .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
+                [0] = { .offset=0,  .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
+                [1] = { .offset=12, .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
+                [2] = { .offset=0,  .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
             }
         },
         .shader = shd,

--- a/d3d11/mipmap-d3d11.c
+++ b/d3d11/mipmap-d3d11.c
@@ -119,6 +119,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "TEXCOORD"
+        },
         .vs = {
             .uniform_blocks[0].size = sizeof(vs_params_t),
             .source =
@@ -155,8 +159,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc) {
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/d3d11/mrt-d3d11.c
+++ b/d3d11/mrt-d3d11.c
@@ -125,6 +125,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* a shader to render a cube into MRT offscreen render targets */
     sg_shader offscreen_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "BRIGHT"
+        },
         .vs.uniform_blocks[0].size = sizeof(offscreen_params_t),
         .vs.source = 
             "cbuffer params: register(b0) {\n"
@@ -164,8 +168,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         .layout = {
             .buffers[0].stride = sizeof(vertex_t),
             .attrs = {
-                [0] = { .sem_name="POSITION", .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="BRIGHT", .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
+                [0] = { .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
+                [1] = { .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
             }
         },
         .shader = offscreen_shd,
@@ -200,6 +204,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     /* a shader to render a fullscreen rectangle, which 'composes'
        the 3 offscreen render target images onto the screen */
     sg_shader fsq_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs[0].sem_name = "POSITION",
         .vs.uniform_blocks[0].size = sizeof(params_t),
         .fs.images = {
             [0].type=SG_IMAGETYPE_2D,
@@ -250,9 +255,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     
     /* the pipeline object for the fullscreen rectangle */
     sg_pipeline fsq_pip = sg_make_pipeline(&(sg_pipeline_desc){
-        .layout = {
-            .attrs[0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT2 }
-        },
+        .layout.attrs[0].format=SG_VERTEXFORMAT_FLOAT2,
         .shader = fsq_shd,
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP
     });
@@ -271,11 +274,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
        of the offscreen render target contents
     */
     sg_pipeline dbg_pip = sg_make_pipeline(&(sg_pipeline_desc){
-        .layout = {
-            .attrs[0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT2 }
-        },
+        .layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2,
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP,
         .shader = sg_make_shader(&(sg_shader_desc){
+            .attrs[0].sem_name = "POSITION",
             .vs.source =
                 "struct vs_in {\n"
                 "  float2 pos: POSITION;\n"

--- a/d3d11/offscreen-d3d11.c
+++ b/d3d11/offscreen-d3d11.c
@@ -115,6 +115,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* shader for non-textured cube, rendered in offscreen pass */
     sg_shader offscreen_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "COLOR"
+        },
         .vs.uniform_blocks[0].size = sizeof(vs_params_t),
         .vs.source = 
             "cbuffer params: register(b0) {\n"
@@ -142,6 +146,11 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* ...and a second shader for rendering a textured cube in the default pass */
     sg_shader default_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POSITION",
+            [1].sem_name = "COLOR",
+            [2].sem_name = "TEXCOORD"
+        },
         .vs.uniform_blocks[0].size = sizeof(vs_params_t),
         .fs.images[0].type = SG_IMAGETYPE_2D,
         .vs.source =
@@ -179,8 +188,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
             /* skip the uv coords */
             .buffers[0].stride = 36,
             .attrs = {
-                [0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             },
         },
         .shader = offscreen_shd,
@@ -200,9 +209,9 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline default_pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = default_shd,

--- a/d3d11/quad-d3d11.c
+++ b/d3d11/quad-d3d11.c
@@ -43,6 +43,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* a shader to render the quad */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POS",
+            [1].sem_name = "COLOR"
+        },
         .vs.source =
             "struct vs_in {\n"
             "  float4 pos: POS;\n"
@@ -72,8 +76,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
             /* test to provide attr offsets, but no buffer stride, this should compute the stride */
             .attrs = {
                 /* vertex attrs can also be bound by location instead of name (but not in GLES2) */
-                [0] = { .sem_name="POS", .offset=0, .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="COLOR", .offset=12, .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0] = { .offset=0, .format=SG_VERTEXFORMAT_FLOAT3 },
+                [1] = { .offset=12, .format=SG_VERTEXFORMAT_FLOAT4 }
             }
         }
     });

--- a/d3d11/texcube-d3d11.c
+++ b/d3d11/texcube-d3d11.c
@@ -104,6 +104,11 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .sem_name="POSITION" },
+            [1] = { .sem_name="COLOR", .sem_index=1 },
+            [2] = { .sem_name="TEXCOORD", .sem_index=1 }
+        },
         .vs.uniform_blocks[0].size = sizeof(vs_params_t),
         .fs.images[0].type = SG_IMAGETYPE_2D,
         .vs.source =
@@ -139,9 +144,9 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name="COLOR", .sem_index=1, .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .sem_name="TEXCOORD", .sem_index=1, .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/d3d11/triangle-d3d11.c
+++ b/d3d11/triangle-d3d11.c
@@ -43,6 +43,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
     /* a shader to render the triangle */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].sem_name = "POS",
+            [1].sem_name = "COLOR"
+        },
         .vs.source =
             "struct vs_in {\n"
             "  float4 pos: POS;\n"
@@ -69,8 +73,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         /* if the vertex layout doesn't have gaps, don't need to provide strides and offsets */
         .layout = {
             .attrs = {
-                [0] = { .sem_name = "POS", .format = SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .sem_name = "COLOR", .format = SG_VERTEXFORMAT_FLOAT4 }
+                [0].format = SG_VERTEXFORMAT_FLOAT3,
+                [1].format = SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = shd

--- a/glfw/arraytex-glfw.c
+++ b/glfw/arraytex-glfw.c
@@ -154,8 +154,8 @@ int main() {
             "uniform vec2 offset0;\n"
             "uniform vec2 offset1;\n"
             "uniform vec2 offset2;\n"
-            "in vec4 position;\n"
-            "in vec2 texcoord0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec2 texcoord0;\n"
             "out vec3 uv0;\n"
             "out vec3 uv1;\n"
             "out vec3 uv2;\n"
@@ -184,8 +184,8 @@ int main() {
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/glfw/blend-glfw.c
+++ b/glfw/blend-glfw.c
@@ -63,7 +63,7 @@ int main() {
     sg_shader bg_shd = sg_make_shader(&(sg_shader_desc){
         .vs.source =
             "#version 330\n"
-            "in vec2 position;\n"
+            "layout(location=0) in vec2 position;\n"
             "void main() {\n"
             "  gl_Position = vec4(position, 0.5, 1.0);\n"
             "}\n",
@@ -90,7 +90,7 @@ int main() {
         .layout = {
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = bg_shd,
@@ -108,8 +108,8 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in vec4 color0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec4 color0;\n"
             "out vec4 color;\n"
             "void main() {\n"
             "  gl_Position = mvp * position;\n"
@@ -128,8 +128,8 @@ int main() {
     sg_pipeline_desc pip_desc = {
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = quad_shd,

--- a/glfw/bufferoffsets-glfw.c
+++ b/glfw/bufferoffsets-glfw.c
@@ -72,8 +72,8 @@ int main() {
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
         .vs.source =
             "#version 330\n"
-            "in vec2 pos;"
-            "in vec3 color0;"
+            "layout(location=0) in vec2 pos;"
+            "layout(location=1) in vec3 color0;"
             "out vec4 color;"
             "void main() {"
             "  gl_Position = vec4(pos, 0.5, 1.0);\n"
@@ -94,8 +94,8 @@ int main() {
         .index_type = SG_INDEXTYPE_UINT16,
         .layout = {
             .attrs = {
-                [0] = { .name="pos", .format=SG_VERTEXFORMAT_FLOAT2 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT3 }
+                [0].format=SG_VERTEXFORMAT_FLOAT2,
+                [1].format=SG_VERTEXFORMAT_FLOAT3
             }
         }
     });

--- a/glfw/cube-glfw.c
+++ b/glfw/cube-glfw.c
@@ -104,11 +104,14 @@ int main() {
                 [0] = { .name="mvp", .type=SG_UNIFORMTYPE_MAT4 }
             }
         },
+        /* NOTE: since the shader defines explicit attribute locations,
+           we don't need to provide an attribute name lookup table in the shader
+        */
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in vec4 color0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec4 color0;\n"
             "out vec4 color;\n"
             "void main() {\n"
             "  gl_Position = mvp * position;\n"
@@ -129,8 +132,8 @@ int main() {
             /* test to provide buffer stride, but no attr offsets */
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = shd,

--- a/glfw/dyntex-glfw.c
+++ b/glfw/dyntex-glfw.c
@@ -129,9 +129,9 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in vec4 color0;\n"
-            "in vec2 texcoord0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec4 color0;\n"
+            "layout(location=2) in vec2 texcoord0;\n"
             "out vec2 uv;"
             "out vec4 color;"
             "void main() {\n"
@@ -154,9 +154,9 @@ int main() {
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position",   .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0",     .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0",  .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/glfw/imgui-glfw.cc
+++ b/glfw/imgui-glfw.cc
@@ -136,9 +136,9 @@ int main() {
     shd_desc.vs.source =
         "#version 330\n"
         "uniform vec2 disp_size;\n"
-        "in vec2 position;\n"
-        "in vec2 texcoord0;\n"
-        "in vec4 color0;\n"
+        "layout(location=0) in vec2 position;\n"
+        "layout(location=1) in vec2 texcoord0;\n"
+        "layout(location=2) in vec4 color0;\n"
         "out vec2 uv;\n"
         "out vec4 color;\n"
         "void main() {\n"
@@ -163,9 +163,9 @@ int main() {
     sg_pipeline_desc pip_desc = { };
     pip_desc.layout.buffers[0].stride = sizeof(ImDrawVert);
     auto& attrs = pip_desc.layout.attrs;
-    attrs[0].name = "position";  attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
-    attrs[1].name = "texcoord0"; attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
-    attrs[2].name = "color0";    attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
+    attrs[0].format = SG_VERTEXFORMAT_FLOAT2;
+    attrs[1].format = SG_VERTEXFORMAT_FLOAT2;
+    attrs[2].format = SG_VERTEXFORMAT_UBYTE4N;
     pip_desc.shader = shd;
     pip_desc.index_type = SG_INDEXTYPE_UINT16;
     pip_desc.blend.enabled = true;

--- a/glfw/inject-glfw.c
+++ b/glfw/inject-glfw.c
@@ -156,8 +156,8 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in vec2 texcoord0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec2 texcoord0;\n"
             "out vec2 uv;"
             "void main() {\n"
             "  gl_Position = mvp * position;\n"
@@ -177,8 +177,8 @@ int main() {
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/glfw/instancing-glfw.c
+++ b/glfw/instancing-glfw.c
@@ -94,9 +94,9 @@ int main() {
         .vs.source = 
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec3 position;\n"
-            "in vec4 color0;\n"
-            "in vec3 instance_pos;\n"
+            "layout(location=0) in vec3 position;\n"
+            "layout(location=1) in vec4 color0;\n"
+            "layout(location=2) in vec3 instance_pos;\n"
             "out vec4 color;\n"
             "void main() {\n"
             "  vec4 pos = vec4(position + instance_pos, 1.0);"
@@ -120,9 +120,9 @@ int main() {
                 [1] = { .stride = 12, .step_func=SG_VERTEXSTEP_PER_INSTANCE }
             },
             .attrs = {
-                [0] = { .name="position", .offset = 0, .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
-                [1] = { .name="color0", .offset = 12, .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
-                [2] = { .name="instance_pos", .offset = 0, .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
+                [0] = { .offset = 0,  .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
+                [1] = { .offset = 12, .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
+                [2] = { .offset = 0,  .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
             }
         },
         .shader = shd,

--- a/glfw/mipmap-glfw.c
+++ b/glfw/mipmap-glfw.c
@@ -137,8 +137,8 @@ int main() {
             .source =
                 "#version 330\n"
                 "uniform mat4 mvp;\n"
-                "in vec4 position;\n"
-                "in vec2 texcoord0;\n"
+                "layout(location=0) in vec4 position;\n"
+                "layout(location=1) in vec2 texcoord0;\n"
                 "out vec2 uv;\n"
                 "void main() {\n"
                 "  gl_Position = mvp * position;\n"
@@ -162,8 +162,8 @@ int main() {
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc) {
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/glfw/mrt-glfw.c
+++ b/glfw/mrt-glfw.c
@@ -142,8 +142,8 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in float bright0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in float bright0;\n"
             "out float bright;\n"
             "void main() {\n"
             "  gl_Position = mvp * position;\n"
@@ -175,8 +175,8 @@ int main() {
                 /* offsets are not strictly needed here because the vertex layout 
                    is gapless, but this demonstrates that offsetof() can be used
                 */
-                [0] = { .name="position", .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="bright0", .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
+                [0] = { .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
+                [1] = { .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
             }
         },
         .shader = offscreen_shd,
@@ -230,7 +230,7 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform vec2 offset;"
-            "in vec2 pos;\n"
+            "layout(location=0) in vec2 pos;\n"
             "out vec2 uv0;\n"
             "out vec2 uv1;\n"
             "out vec2 uv2;\n"
@@ -260,7 +260,7 @@ int main() {
     /* the pipeline object for the fullscreen rectangle */
     sg_pipeline fsq_pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
-            .attrs[0] = { .name="pos", .format=SG_VERTEXFORMAT_FLOAT2 }
+            .attrs[0].format=SG_VERTEXFORMAT_FLOAT2
         },
         .shader = fsq_shd,
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP
@@ -271,13 +271,13 @@ int main() {
     */
     sg_pipeline dbg_pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
-            .attrs[0] = { .name="pos", .format=SG_VERTEXFORMAT_FLOAT2 }
+            .attrs[0].format=SG_VERTEXFORMAT_FLOAT2
         },
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP,
         .shader = sg_make_shader(&(sg_shader_desc){
             .vs.source =
                 "#version 330\n"
-                "in vec2 pos;\n"
+                "layout(location=0) in vec2 pos;\n"
                 "out vec2 uv;\n"
                 "void main() {\n"
                 "  gl_Position = vec4(pos*2.0-1.0, 0.5, 1.0);\n"

--- a/glfw/multiwindow-glfw.c
+++ b/glfw/multiwindow-glfw.c
@@ -124,8 +124,8 @@ int main() {
             .vs.source =
                 "#version 330\n"
                 "uniform mat4 mvp;\n"
-                "in vec4 position;\n"
-                "in vec4 color0;\n"
+                "layout(location=0) in vec4 position;\n"
+                "layout(location=1) in vec4 color0;\n"
                 "out vec4 color;\n"
                 "void main() {\n"
                 "  gl_Position = mvp * position;\n"
@@ -144,8 +144,8 @@ int main() {
                 /* test to provide buffer stride, but no attr offsets */
                 .buffers[0].stride = 28,
                 .attrs = {
-                    [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                    [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                    [0].format=SG_VERTEXFORMAT_FLOAT3,
+                    [1].format=SG_VERTEXFORMAT_FLOAT4
                 }
             },
             .shader = shd,

--- a/glfw/noninterleaved-glfw.c
+++ b/glfw/noninterleaved-glfw.c
@@ -91,8 +91,8 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in vec4 color0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec4 color0;\n"
             "out vec4 color;\n"
             "void main() {\n"
             "  gl_Position = mvp * position;\n"
@@ -113,9 +113,9 @@ int main() {
             /* note how the vertex components are pulled from different buffer bind slots */
             .attrs = {
                 /* positions come from vertex buffer slot 0 */
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
+                [0] = { .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
                 /* colors come from vertex buffer slot 1 */
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=1 }
+                [1] = { .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=1 }
             }
         },
         .shader = shd,

--- a/glfw/offscreen-glfw.c
+++ b/glfw/offscreen-glfw.c
@@ -134,8 +134,8 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in vec4 color0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec4 color0;\n"
             "out vec4 color;\n"
             "void main() {\n"
             "  gl_Position = mvp * position;\n"
@@ -162,9 +162,9 @@ int main() {
         .vs.source =
             "#version 330\n"
             "uniform mat4 mvp;\n"
-            "in vec4 position;\n"
-            "in vec4 color0;\n"
-            "in vec2 texcoord0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec4 color0;\n"
+            "layout(location=2) in vec2 texcoord0;\n"
             "out vec4 color;\n"
             "out vec2 uv;\n"
             "void main() {\n"
@@ -190,8 +190,8 @@ int main() {
             .buffers[0].stride = 36,
             /* but don't need to provide attr offsets, because pos and color are continuous */
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = offscreen_shd,
@@ -212,9 +212,9 @@ int main() {
         .layout = {
             /* don't need to provide buffer stride or attr offsets, no gaps here */
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = default_shd,

--- a/glfw/triangle-glfw.c
+++ b/glfw/triangle-glfw.c
@@ -44,6 +44,13 @@ int main() {
 
     /* a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        /* vertex attribute lookup by name is optional in GL3.x, we
+           could also use "layout(location=N)" in the shader
+        */
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0"
+        },
         .vs.source = 
             "#version 330\n"
             "in vec4 position;\n"
@@ -68,8 +75,8 @@ int main() {
         /* if the vertex layout doesn't have gaps, don't need to provide strides and offsets */
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         }
     });

--- a/html5/arraytex-emsc.c
+++ b/html5/arraytex-emsc.c
@@ -145,6 +145,10 @@ int main() {
 
     /* shader to sample from array texture */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "texcoord0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -193,8 +197,8 @@ int main() {
     pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/html5/blend-emsc.c
+++ b/html5/blend-emsc.c
@@ -63,6 +63,9 @@ int main() {
 
     /* a shader for the fullscreen background quad */
     sg_shader bg_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position"
+        },
         .vs.source =
             "attribute vec2 position;\n"
             "void main() {\n"
@@ -90,7 +93,7 @@ int main() {
         .layout = {
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = bg_shd,
@@ -99,6 +102,10 @@ int main() {
 
     /* a shader for the blended quads */
     sg_shader quad_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -126,8 +133,8 @@ int main() {
     sg_pipeline_desc pip_desc = {
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = quad_shd,

--- a/html5/bufferoffsets-emsc.c
+++ b/html5/bufferoffsets-emsc.c
@@ -63,6 +63,10 @@ int main() {
 
     /* create a shader to render 2D colored shapes */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "pos",
+            [1].name = "color0"
+        },
         .vs.source =
             "attribute vec2 pos;"
             "attribute vec3 color0;"
@@ -85,8 +89,8 @@ int main() {
         .index_type = SG_INDEXTYPE_UINT16,
         .layout = {
             .attrs = {
-                [0] = { .name="pos", .format=SG_VERTEXFORMAT_FLOAT2 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT3 }
+                [0].format=SG_VERTEXFORMAT_FLOAT2,
+                [1].format=SG_VERTEXFORMAT_FLOAT3
             }
         }
     });

--- a/html5/cube-emsc.c
+++ b/html5/cube-emsc.c
@@ -89,6 +89,10 @@ int main() {
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -118,8 +122,8 @@ int main() {
             /* test to provide buffer stride, but no attr offsets */
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = shd,

--- a/html5/dyntex-emsc.c
+++ b/html5/dyntex-emsc.c
@@ -118,6 +118,11 @@ int main() {
 
     /* a shader to render textured cube */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0",
+            [2].name = "texcoord0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -151,9 +156,9 @@ int main() {
     pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position",   .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0",     .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0",  .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/html5/imgui-emsc.cc
+++ b/html5/imgui-emsc.cc
@@ -171,6 +171,11 @@ int main() {
 
     // shader object for imgui rendering
     sg_shader_desc shd_desc = {
+        .attrs = {
+            [0].name = "position",
+            [1].name = "texcoord0",
+            [2].name = "color0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -206,9 +211,9 @@ int main() {
         .layout = {
             .buffers[0].stride = sizeof(ImDrawVert),
             .attrs = {
-                [0] = { .name="position", .offset=offsetof(ImDrawVert,pos), .format=SG_VERTEXFORMAT_FLOAT2 },
-                [1] = { .name="texcoord0", .offset=offsetof(ImDrawVert,uv), .format=SG_VERTEXFORMAT_FLOAT2 },
-                [2] = { .name="color0", .offset=offsetof(ImDrawVert,col), .format=SG_VERTEXFORMAT_UBYTE4N }
+                [0] = { .offset=offsetof(ImDrawVert,pos), .format=SG_VERTEXFORMAT_FLOAT2 },
+                [1] = { .offset=offsetof(ImDrawVert,uv), .format=SG_VERTEXFORMAT_FLOAT2 },
+                [2] = { .offset=offsetof(ImDrawVert,col), .format=SG_VERTEXFORMAT_UBYTE4N }
             }
         },
         .shader = shd,

--- a/html5/inject-emsc.c
+++ b/html5/inject-emsc.c
@@ -134,6 +134,10 @@ int main() {
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "texcoord0"
+        },
         .vs.uniform_blocks[0] = { 
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -163,8 +167,8 @@ int main() {
     pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/html5/instancing-emsc.c
+++ b/html5/instancing-emsc.c
@@ -89,6 +89,11 @@ int main() {
 
     /* create a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0",
+            [2].name = "instance_pos"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -119,9 +124,9 @@ int main() {
         .layout = {
             .buffers[1].step_func = SG_VERTEXSTEP_PER_INSTANCE,
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
-                [2] = { .name="instance_pos", .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
+                [0] = { .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
+                [1] = { .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
+                [2] = { .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
             }
         },
         .shader = shd,

--- a/html5/mipmap-emsc.c
+++ b/html5/mipmap-emsc.c
@@ -121,6 +121,10 @@ int main() {
 
     /* shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "texcoord0"
+        },
         .vs = {
             .uniform_blocks[0] = {
                 .size = sizeof(vs_params_t),
@@ -154,8 +158,8 @@ int main() {
     pip = sg_make_pipeline(&(sg_pipeline_desc) {
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/html5/mrt-emsc.c
+++ b/html5/mrt-emsc.c
@@ -155,6 +155,10 @@ int main() {
 
     /* a shader to render the cube into offscreen MRT render targets */
     sg_shader offscreen_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "bright0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(offscreen_params_t),
             .uniforms = {
@@ -190,8 +194,8 @@ int main() {
         .layout = {
             .buffers[0].stride = sizeof(vertex_t),
             .attrs = {
-                [0] = { .name="position", .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="bright0", .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
+                [0] = { .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
+                [1] = { .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
             }
         },
         .shader = offscreen_shd,
@@ -231,6 +235,7 @@ int main() {
     /* a shader to render a fullscreen rectangle, which 'composes'
        the 3 offscreen render target images onto the screen */
     sg_shader fsq_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs[0].name = "pos",
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -275,9 +280,7 @@ int main() {
     
     /* the pipeline object for the fullscreen rectangle */
     fsq_pip = sg_make_pipeline(&(sg_pipeline_desc){
-        .layout = {
-            .attrs[0] = { .name="pos", .format=SG_VERTEXFORMAT_FLOAT2 }
-        },
+        .layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT2,
         .shader = fsq_shd,
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP
     });
@@ -287,10 +290,11 @@ int main() {
     */
     dbg_pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
-            .attrs[0] = { .name="pos", .format=SG_VERTEXFORMAT_FLOAT2 }
+            .attrs[0].format=SG_VERTEXFORMAT_FLOAT2
         },
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP,
         .shader = sg_make_shader(&(sg_shader_desc){
+            .attrs[0].name = "pos",
             .vs.source =
                 "#version 300 es\n"
                 "uniform vec2 offset;"

--- a/html5/noninterleaved-emsc.c
+++ b/html5/noninterleaved-emsc.c
@@ -79,6 +79,10 @@ int main() {
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -108,9 +112,9 @@ int main() {
             /* note how the vertex components are pulled from different buffer bind slots */
             .attrs = {
                 /* positions come from vertex buffer slot 0 */
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
+                [0] = { .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
                 /* colors come from vertex buffer slot 1 */
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=1 }
+                [1] = { .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=1 }
             }
         },
         .shader = shd,

--- a/html5/offscreen-emsc.c
+++ b/html5/offscreen-emsc.c
@@ -123,6 +123,10 @@ int main() {
 
     /* shader for the non-textured cube, rendered in the offscreen pass */
     sg_shader offscreen_shd = sg_make_shader(&(sg_shader_desc) {
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -148,6 +152,11 @@ int main() {
 
     /* ...and a second shader for rendering a textured cube in the default pass */
     sg_shader default_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0",
+            [2].name = "texcoord0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -184,8 +193,8 @@ int main() {
             .buffers[0].stride = 36,
             /* but don't need to provide attr offsets, because pos and color are continuous */
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = offscreen_shd,
@@ -206,9 +215,9 @@ int main() {
         .layout = {
             /* don't need to provide buffer stride or attr offsets, no gaps here */
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = default_shd,

--- a/html5/quad-emsc.c
+++ b/html5/quad-emsc.c
@@ -53,6 +53,10 @@ int main() {
 
     /* create a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc) {
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0"
+        },
         .vs.source =
             "attribute vec4 position;\n"
             "attribute vec4 color0;\n"
@@ -75,8 +79,8 @@ int main() {
             /* test to provide attr offsets, but no buffer stride, this should compute the stride */
             .attrs = {
                 /* vertex attrs can also be bound by location instead of name (but not in GLES2) */
-                [0] = { .offset=0, .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .offset=12, .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = shd,

--- a/html5/texcube-emsc.c
+++ b/html5/texcube-emsc.c
@@ -105,6 +105,11 @@ int main() {
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0",
+            [2].name = "texcoord0"
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -138,9 +143,9 @@ int main() {
     pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/html5/triangle-emsc.c
+++ b/html5/triangle-emsc.c
@@ -40,6 +40,10 @@ int main() {
 
     /* create a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0].name = "position",
+            [1].name = "color0"
+        },
         .vs.source =
             "attribute vec4 position;\n"
             "attribute vec4 color0;\n"
@@ -62,8 +66,8 @@ int main() {
         .shader = shd,
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
     });

--- a/sapp/arraytex-sapp.c
+++ b/sapp/arraytex-sapp.c
@@ -140,6 +140,10 @@ void init(void) {
 
     /* shader to sample from array texture */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="texcoord0", .sem_name="TEXCOORD" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -159,8 +163,8 @@ void init(void) {
     pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position", .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/sapp/blend-sapp.c
+++ b/sapp/blend-sapp.c
@@ -66,6 +66,7 @@ void init(void) {
 
     /* a shader for the fullscreen background quad */
     sg_shader bg_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs[0] = { .name="position", .sem_name="POS" },
         .vs.source = bg_vs_src,
         .fs = {
             .uniform_blocks[0] = {
@@ -87,7 +88,7 @@ void init(void) {
         .layout = {
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = bg_shd,
@@ -97,6 +98,10 @@ void init(void) {
 
     /* a shader for the blended quads */
     sg_shader quad_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POS" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs = {
             .uniform_blocks[0] = {
                 .size = sizeof(vs_params_t),
@@ -113,8 +118,8 @@ void init(void) {
     sg_pipeline_desc pip_desc = {
         .layout = {
             .attrs = {
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = quad_shd,

--- a/sapp/bufferoffsets-sapp.c
+++ b/sapp/bufferoffsets-sapp.c
@@ -63,6 +63,10 @@ void init(void) {
 
     /* a shader and pipeline to render 2D shapes */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POS" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs.source = vs_src,
         .fs.source = fs_src
     });
@@ -71,8 +75,8 @@ void init(void) {
         .index_type = SG_INDEXTYPE_UINT16,
         .layout = {
             .attrs = {
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT2 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT3 }
+                [0].format=SG_VERTEXFORMAT_FLOAT2,
+                [1].format=SG_VERTEXFORMAT_FLOAT3
             }
         }
     });

--- a/sapp/cube-sapp.c
+++ b/sapp/cube-sapp.c
@@ -88,6 +88,10 @@ void init(void) {
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc) {
+        .attrs = {
+            [0] = { .name="position", .sem_name="POS" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -105,8 +109,8 @@ void init(void) {
             /* test to provide buffer stride, but no attr offsets */
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = shd,

--- a/sapp/cubemaprt-sapp.c
+++ b/sapp/cubemaprt-sapp.c
@@ -157,11 +157,15 @@ void init(void) {
     };
     sg_layout_desc layout_desc = {
         .attrs = {
-            [0] = { .name="pos", .sem_name="POS", .offset=offsetof(vertex_t, pos), .format=SG_VERTEXFORMAT_FLOAT3 },
-            [1] = { .name="norm", .sem_name="NORM", .offset=offsetof(vertex_t, norm), .format=SG_VERTEXFORMAT_FLOAT3 }
+            [0] = { .offset=offsetof(vertex_t, pos), .format=SG_VERTEXFORMAT_FLOAT3 },
+            [1] = { .offset=offsetof(vertex_t, norm), .format=SG_VERTEXFORMAT_FLOAT3 }
         }
     };
     sg_shader offscreen_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="pos", .sem_name="POS" },
+            [1] = { .name="norm", .sem_name="NORM" }
+        },
         .vs = {
             .source = vs_src,
             .uniform_blocks[0] = ub_desc
@@ -194,6 +198,10 @@ void init(void) {
 
     /* shader and pipeline objects for display-rendering */
     sg_shader display_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="pos", .sem_name="POS" },
+            [1] = { .name="norm", .sem_name="NORM" }
+        },
         .vs = {
             .source = vs_src,
             .uniform_blocks[0] = ub_desc

--- a/sapp/dyntex-sapp.c
+++ b/sapp/dyntex-sapp.c
@@ -114,6 +114,11 @@ void init(void) {
 
     /* a shader to render a textured cube */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="color0", .sem_name="COLOR" },
+            [2] = { .name="texcoord0", .sem_name="TEXCOORD0" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -130,9 +135,9 @@ void init(void) {
     pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position",   .sem_name="POSITION",   .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0",     .sem_name="COLOR",      .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0",  .sem_name="TEXCOORD",   .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/sapp/instancing-sapp.c
+++ b/sapp/instancing-sapp.c
@@ -85,6 +85,11 @@ void init(void) {
 
     /* a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="color0", .sem_name="COLOR" },
+            [2] = { .name="instance_pos", .sem_name="INSTPOS" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -102,9 +107,9 @@ void init(void) {
             /* vertex buffer at slot 1 must step per instance */
             .buffers[1].step_func = SG_VERTEXSTEP_PER_INSTANCE,
             .attrs = {
-                [0] = { .name="position",     .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
-                [1] = { .name="color0",       .sem_name="COLOR",    .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
-                [2] = { .name="instance_pos", .sem_name="INSTPOS",  .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
+                [0] = { .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
+                [1] = { .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=0 },
+                [2] = { .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=1 }
             }
         },
         .shader = shd,

--- a/sapp/mipmap-sapp.c
+++ b/sapp/mipmap-sapp.c
@@ -122,6 +122,10 @@ void init(void) {
 
     /* shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="texcoord0", .sem_name="TEXCOORD0" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -137,8 +141,8 @@ void init(void) {
     pip = sg_make_pipeline(&(sg_pipeline_desc) {
         .layout = {
             .attrs = {
-                [0] = { .name="position", .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="texcoord0", .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT2
             } 
         },
         .shader = shd,

--- a/sapp/mrt-sapp.c
+++ b/sapp/mrt-sapp.c
@@ -185,6 +185,10 @@ void init(void) {
 
     /* a shader to render the cube into offscreen MRT render targest */
     sg_shader offscreen_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="bright0", .sem_name="BRIGHT" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(offscreen_params_t),
             .uniforms = {
@@ -201,8 +205,8 @@ void init(void) {
         .layout = {
             .buffers[0].stride = sizeof(vertex_t),
             .attrs = {
-                [0] = { .name="position", .sem_name="POSITION", .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="bright0", .sem_name="BRIGHT", .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
+                [0] = { .offset=offsetof(vertex_t,x), .format=SG_VERTEXFORMAT_FLOAT3 },
+                [1] = { .offset=offsetof(vertex_t,b), .format=SG_VERTEXFORMAT_FLOAT }
             }
         },
         .shader = offscreen_shd,
@@ -239,6 +243,7 @@ void init(void) {
 
     /* a shader to render a fullscreen rectangle by adding the 3 offscreen-rendered images */
     sg_shader fsq_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs[0] = { .name="pos", .sem_name="POSITION" },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -258,7 +263,7 @@ void init(void) {
     /* the pipeline object to render the fullscreen quad */
     fsq_pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
-            .attrs[0] = { .name="pos", .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT2 }
+            .attrs[0].format=SG_VERTEXFORMAT_FLOAT2
         },
         .shader = fsq_shd,
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP,
@@ -279,10 +284,11 @@ void init(void) {
     /* pipeline and resource bindings to render debug-visualization quads */
     dbg_pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
-            .attrs[0] = { .name="pos", .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT2 }
+            .attrs[0].format=SG_VERTEXFORMAT_FLOAT2
         },
         .primitive_type = SG_PRIMITIVETYPE_TRIANGLE_STRIP,
         .shader = sg_make_shader(&(sg_shader_desc){
+            .attrs[0] = { .name="pos", .sem_name="POSITION" },
             .vs.source = dbg_vs,
             .fs.images[0] = { .name="tex", .type=SG_IMAGETYPE_2D },
             .fs.source = dbg_fs,

--- a/sapp/noentry-sapp.c
+++ b/sapp/noentry-sapp.c
@@ -126,6 +126,10 @@ void init(void* user_data) {
 
     /* create shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc) {
+        .attrs = {
+            [0] = { .name="position", .sem_name="POS" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -142,8 +146,8 @@ void init(void* user_data) {
             /* test to provide buffer stride, but no attr offsets */
             .buffers[0].stride = 28,
             .attrs = {
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format = SG_VERTEXFORMAT_FLOAT3,
+                [1].format = SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = shd,

--- a/sapp/noninterleaved-sapp.c
+++ b/sapp/noninterleaved-sapp.c
@@ -83,6 +83,10 @@ void init(void) {
         not their internal layout
     */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POS" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(vs_params_t),
             .uniforms = {
@@ -102,9 +106,9 @@ void init(void) {
             /* note how the vertex components are pulled from different buffer bind slots */
             .attrs = {
                 /* positions come from vertex buffer slot 0 */
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
+                [0] = { .format=SG_VERTEXFORMAT_FLOAT3, .buffer_index=0 },
                 /* colors come from vertex buffer slot 1 */
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=1 }
+                [1] = { .format=SG_VERTEXFORMAT_FLOAT4, .buffer_index=1 }
             }
         },        .shader = shd,
         .index_type = SG_INDEXTYPE_UINT16,

--- a/sapp/offscreen-sapp.c
+++ b/sapp/offscreen-sapp.c
@@ -129,6 +129,10 @@ void init(void) {
 
     /* a shader for a non-textured cube, rendered in the offscreen pass */
     sg_shader offscreen_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -143,6 +147,11 @@ void init(void) {
     /* ...and another shader for the display-pass, rendering a textured cube
        using the offscreen render target as texture */
     sg_shader default_shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="color0", .sem_name="COLOR" },
+            [2] = { .name="texcoord0", .sem_name="TEXCOORD" }
+        },
         .vs.uniform_blocks[0] = {
             .size = sizeof(params_t),
             .uniforms = {
@@ -162,8 +171,8 @@ void init(void) {
             .buffers[0].stride = 36,
             /* but don't need to provide attr offsets, because pos and color are continuous */
             .attrs = {
-                [0] = { .name="position", .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .shader = offscreen_shd,
@@ -188,9 +197,9 @@ void init(void) {
         .layout = {
             /* don't need to provide buffer stride or attr offsets, no gaps here */
             .attrs = {
-                [0] = { .name="position", .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0", .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = default_shd,

--- a/sapp/quad-sapp.c
+++ b/sapp/quad-sapp.c
@@ -52,6 +52,10 @@ void init(void) {
 
     /* a shader (use separate shader sources here */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POS" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs.source = vs_src,
         .fs.source = fs_src,
         .label = "quad-shader"
@@ -63,8 +67,8 @@ void init(void) {
         .index_type = SG_INDEXTYPE_UINT16,
         .layout = {
             .attrs = {
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .label = "quad-pipeline"

--- a/sapp/texcube-sapp.c
+++ b/sapp/texcube-sapp.c
@@ -110,6 +110,11 @@ void init(void) {
 
     /* a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc) {
+        .attrs = {
+            [0] = { .name="position", .sem_name="POSITION" },
+            [1] = { .name="color0", .sem_name="COLOR0" },
+            [2] = { .name="texcoord0", .sem_name="TEXCOORD" }
+        },
         .vs = {
             .uniform_blocks[0] = {
                 .size = sizeof(vs_params_t),
@@ -130,9 +135,9 @@ void init(void) {
     pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs = {
-                [0] = { .name="position", .sem_name="POSITION", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 },
-                [2] = { .name="texcoord0", .sem_name="TEXCOORD", .format=SG_VERTEXFORMAT_FLOAT2 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4,
+                [2].format=SG_VERTEXFORMAT_FLOAT2
             }
         },
         .shader = shd,

--- a/sapp/triangle-sapp.c
+++ b/sapp/triangle-sapp.c
@@ -42,6 +42,10 @@ void init(void) {
 
     /* create a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name="position", .sem_name="POS" },
+            [1] = { .name="color0", .sem_name="COLOR" }
+        },
         .vs.source = vs_src,
         .fs.source = fs_src,
         .label = "triangle-shader"
@@ -53,8 +57,8 @@ void init(void) {
         .shader = shd,
         .layout = {
             .attrs = {
-                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         },
         .label = "triangle-pipeline"

--- a/tests/sokol-gfx-test.c
+++ b/tests/sokol-gfx-test.c
@@ -379,8 +379,8 @@ static void test_make_destroy_pipelines(void) {
         .shader = sg_make_shader(&(sg_shader_desc){ 0 }),
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0] = { .format=SG_VERTEXFORMAT_FLOAT3 },
+                [1] = { .format=SG_VERTEXFORMAT_FLOAT4 }
             }
         },
     };


### PR DESCRIPTION
Vertex attribute names/semantics have moved from sg_pipeline_desc to sg_shader_desc.