### PR TITLE
use os.path.join to get correct path under windows

### DIFF
--- a/fips
+++ b/fips
@@ -4,14 +4,14 @@ import os
 import sys
 import subprocess
 proj_path = os.path.dirname(os.path.abspath(__file__))
-fips_path = os.path.dirname(proj_path) + '/fips'
+fips_path = os.path.join(os.path.dirname(proj_path), 'fips')
 if not os.path.isdir(fips_path) :
     print("\033[93m=== cloning fips build system to '{}':\033[0m".format(fips_path))
-    subprocess.call(['git', 'clone', 'https://github.com/floooh/fips.git', fips_path]) 
+    subprocess.call(['git', 'clone', 'https://github.com/floooh/fips.git', fips_path])
 sys.path.insert(0,fips_path)
 try :
     from mod import fips
 except ImportError :
-    print("\033[91m[ERROR]\033[0m failed to initialize fips build system in '{}'".format(proj_path)) 
+    print("\033[91m[ERROR]\033[0m failed to initialize fips build system in '{}'".format(proj_path))
     sys.exit(10)
 fips.run(fips_path, proj_path, sys.argv)


### PR DESCRIPTION
For some reason this is working in your repository, but I had my github CI workflow choke on the fips path composition with + '/fips' when I upgraded to windows-latest from windows-2016.

When I changed it to use os.path.join it worked instead. Figured I'll submit it upstream.