### PR TITLE
Fix sg_setup evaluated to zero

### DIFF
--- a/html5/imgui-emsc.cc
+++ b/html5/imgui-emsc.cc
@@ -45,7 +45,8 @@ int main() {
 
     /* setup sokol_gfx and sokol_time */
     stm_setup();
-    sg_setup({ });
+  	sg_desc desc = {};
+    sg_setup(&desc);
     assert(sg_isvalid());
 
     // setup the ImGui environment


### PR DESCRIPTION
Doing that:
> sg_setup({ });

Result to a null ptr on the JS side

JS side:
> _sg_setup(0); //@line 48 "../../sokol-samples/html5/imgui-emsc.cc"

With an assert fail:
>Shell_Common.js:490 Assertion failed: desc, at: ../../sokol\sokol_gfx.h,13937,sg_setup
