### PR TITLE
nuklear-sapp example usage of sokol_nuklear.h

### DIFF
--- a/fips.yml
+++ b/fips.yml
@@ -21,4 +21,5 @@ imports:
     git: https://github.com/fips-libs/fips-utils
   fips-dawn:
     git: https://github.com/fips-libs/fips-dawn
-
+  fips-nuklear:
+    git: https://github.com/fips-libs/fips-nuklear

--- a/sapp/CMakeLists.txt
+++ b/sapp/CMakeLists.txt
@@ -2,6 +2,19 @@
 # the sokol_config() macro is in the top-level CMakeLists.txt file!
 sokol_config()
 
+fips_ide_group(Samples/nuklear)
+fips_begin_app(nuklear-sapp windowed)
+    fips_vs_warning_level(3)
+    fips_files(nuklear-sapp.c)
+    fips_deps(sokol)
+fips_end_app()
+fips_begin_app(nuklear-sapp-ui windowed)
+    fips_vs_warning_level(3)
+    fips_files(nuklear-sapp.c)
+    fips_deps(sokol)
+fips_end_app()
+target_compile_definitions(nuklear-sapp-ui PRIVATE)
+
 fips_ide_group(Samples/clear)
 fips_begin_app(clear-sapp windowed)
     fips_vs_warning_level(3)

--- a/sapp/nuklear-sapp.c
+++ b/sapp/nuklear-sapp.c
@@ -1,0 +1,114 @@
+//------------------------------------------------------------------------------
+//  nuklear-sapp.c
+//
+//  Demonstrates Nuklear UI rendering in C via
+//  sokol_gfx.h + sokol_nuklear.h + nuklear.h
+//------------------------------------------------------------------------------
+#define NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#define NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_DEFAULT_FONT
+#define NK_IMPLEMENTATION
+#include "nuklear/nuklear.h"
+
+#define SOKOL_NUKLEAR_IMPL
+#include "sokol_app.h"
+#include "sokol_gfx.h"
+#include "sokol_time.h"
+#include "sokol_glue.h"
+#include "sokol_nuklear.h"
+
+void init(void) {
+    // setup sokol-gfx, sokol-time and sokol-imgui
+    sg_setup(&(sg_desc){
+        .context = sapp_sgcontext()
+    });
+    stm_setup();
+
+    // use sokol-nuklear with all default-options (we're not doing
+    // multi-sampled rendering or using non-default pixel formats)
+    snk_setup(&(snk_desc_t){
+        .dpi_scale = sapp_dpi_scale()
+    });
+}
+
+void frame(void) {
+    struct nk_context *ctx = snk_new_frame();
+
+    // Show a basic Nuklear Window
+    if (nk_begin(ctx, "Demo", nk_rect(50, 50, 200, 200),
+        NK_WINDOW_BORDER|NK_WINDOW_MOVABLE|NK_WINDOW_SCALABLE|
+        NK_WINDOW_CLOSABLE|NK_WINDOW_MINIMIZABLE|NK_WINDOW_TITLE))
+    {
+        nk_menubar_begin(ctx);
+        nk_layout_row_begin(ctx, NK_STATIC, 25, 2);
+        nk_layout_row_push(ctx, 45);
+        if (nk_menu_begin_label(ctx, "FILE", NK_TEXT_LEFT, nk_vec2(120, 200))) {
+            nk_layout_row_dynamic(ctx, 30, 1);
+            nk_menu_item_label(ctx, "OPEN", NK_TEXT_LEFT);
+            nk_menu_item_label(ctx, "CLOSE", NK_TEXT_LEFT);
+            nk_menu_end(ctx);
+        }
+        nk_layout_row_push(ctx, 45);
+        if (nk_menu_begin_label(ctx, "EDIT", NK_TEXT_LEFT, nk_vec2(120, 200))) {
+            nk_layout_row_dynamic(ctx, 30, 1);
+            nk_menu_item_label(ctx, "COPY", NK_TEXT_LEFT);
+            nk_menu_item_label(ctx, "CUT", NK_TEXT_LEFT);
+            nk_menu_item_label(ctx, "PASTE", NK_TEXT_LEFT);
+            nk_menu_end(ctx);
+        }
+        nk_layout_row_end(ctx);
+        nk_menubar_end(ctx);
+
+        enum {EASY, HARD};
+        static int op = EASY;
+        static int property = 20;
+        nk_layout_row_static(ctx, 30, 80, 1);
+        if (nk_button_label(ctx, "button"))
+            fprintf(stdout, "button pressed\n");
+        nk_layout_row_dynamic(ctx, 30, 2);
+        if (nk_option_label(ctx, "easy", op == EASY)) op = EASY;
+        if (nk_option_label(ctx, "hard", op == HARD)) op = HARD;
+        nk_layout_row_dynamic(ctx, 25, 1);
+        nk_property_int(ctx, "Compression:", 0, &property, 100, 10, 1);
+    }
+    nk_end(ctx);
+
+    // the sokol_gfx draw pass
+    sg_begin_default_pass(&(sg_pass_action){
+        .colors[0] = {
+            .action = SG_ACTION_CLEAR, .val = { 0.7f, 0.5f, 0.0f, 1.0f }
+        }
+    }, sapp_width(), sapp_height());
+    snk_render(sapp_width(), sapp_height());
+    sg_end_pass();
+    sg_commit();
+}
+
+void cleanup(void) {
+    snk_shutdown();
+    sg_shutdown();
+}
+
+void input(const sapp_event* event) {
+    snk_handle_event(event);
+}
+
+sapp_desc sokol_main(int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+    return (sapp_desc) {
+        .init_cb = init,
+        .frame_cb = frame,
+        .cleanup_cb = cleanup,
+        .event_cb = input,
+        .high_dpi = true,
+        .enable_clipboard = true,
+        .width = 1024,
+        .height = 768,
+        .window_title = "nuklear (sokol-app)",
+        .ios_keyboard_resizes_canvas = true
+    };
+}


### PR DESCRIPTION
This is a simple example of using sokol_nuklear.h, sokol_app.h with the [Nuklear](https://github.com/Immediate-Mode-UI/Nuklear) immediate mode UI.

Depends on https://github.com/floooh/sokol/pull/473