### PR TITLE
fix: Linux sokol-app compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ To build one of the sokol-app samples on Linux:
 ```sh
 > cd sokol-samples/sapp
 > ../../sokol-tools-bin/bin/linux/sokol-shdc -i cube-sapp.glsl -o cube-sapp.glsl.h -l glsl330
-> cc cube-sapp.c ../libs/sokol/sokol.c -o cube-sapp -DSOKOL_GLCORE33 -I../../sokol -I../libs -lGL -ldl -lm -lpthread -lX11 -lasound
+> cc cube-sapp.c ../libs/sokol/sokol.c -o cube-sapp -DSOKOL_GLCORE33 -I../../sokol -I../libs -lGL -ldl -lm -lpthread -lX11 -lasound -lXi -lXcursor
 ```
 
 ## Many Thanks to:


### PR DESCRIPTION
The existing method gave an error and could not be compiled.

The option `-lxi -lxcursor` was missing, so I added it and the build went through!
