### PR TITLE
Remove sspine_new_frame() calls.

### DIFF
--- a/sapp/spine-contexts-sapp.c
+++ b/sapp/spine-contexts-sapp.c
@@ -99,7 +99,6 @@ static void init(void) {
 static void frame(void) {
     const float delta_time = (float)sapp_frame_duration();
     sfetch_dowork();
-    sspine_new_frame();
 
     // render spine objects in separate contexts, first one by setting the current context,
     // second one by calling function with ctx arg

--- a/sapp/spine-inspector-sapp.c
+++ b/sapp/spine-inspector-sapp.c
@@ -189,9 +189,6 @@ static void frame(void) {
         .delta_time = delta_time,
     });
 
-    // can call Spine functions with invalid or 'incomplete' object handles
-    sspine_new_frame();
-
     // link IK target to mouse (no-op if there's no selected iktarget)
     sspine_set_iktarget_world_pos(state.instance, state.ui.selected.iktarget, state.iktarget_pos);
 

--- a/sapp/spine-layers-sapp.c
+++ b/sapp/spine-layers-sapp.c
@@ -80,7 +80,6 @@ static void init(void) {
 static void frame(void) {
     const float delta_time = (float)sapp_frame_duration();
     sfetch_dowork();
-    sspine_new_frame();
 
     // use a fixed 'virtual' canvas size for the spine layer transform so that
     // the spine scene scales with the window size

--- a/sapp/spine-simple-sapp.c
+++ b/sapp/spine-simple-sapp.c
@@ -276,13 +276,12 @@ static void frame(void) {
         .origin = { .x = w * 0.5f, .y = h * 0.5f }
     };
 
-    // Start a new spine frame, advance the instance animation and draw the instance.
+    // Advance the instance animation and draw the instance.
     // Important to note here is that no actual sokol-gfx rendering happens yet,
     // instead sokol-spine will only record vertices, indices and draw commands.
     // Also, all sokol-spine functions can be called with invalid or 'incomplete'
     // handles, that way we don't need to care about whether the spine objects
     // have actually been created yet (because their data might still be loading)
-    sspine_new_frame();
     sspine_update_instance(state.instance, delta_time);
     sspine_draw_instance_in_layer(state.instance, 0);
 

--- a/sapp/spine-skinsets-sapp.c
+++ b/sapp/spine-skinsets-sapp.c
@@ -222,7 +222,6 @@ static void frame(void) {
 
     // update and draw Spine objects
     uint64_t start_time = stm_now();
-    sspine_new_frame();
     for (uint32_t i = 0; i < NUM_INSTANCES; i++) {
         const uint32_t grid_index = (i + state.t_count) % NUM_INSTANCES;
         const vec2 pos = state.grid[grid_index].pos;

--- a/sapp/spine-switch-skinsets-sapp.c
+++ b/sapp/spine-switch-skinsets-sapp.c
@@ -125,7 +125,6 @@ static void frame(void) {
     sdtx_home();
     sdtx_puts("Press 1, 2, 3 to switch skin sets!");
 
-    sspine_new_frame();
     sspine_update_instance(state.instance, delta_time);
     sspine_draw_instance_in_layer(state.instance, 0);
 


### PR DESCRIPTION
...goes with the sokol-gfx commit listeners feature. This removed the sspine_new_frame() call from sokol_spine.h, and this PR contains the necessary fixes in the Spine samples.