### PR TITLE
Fix vscode build configs for latest fips changes.

### DIFF
--- a/fips-files/configs/d3d11-win64-clang-vscode-debug.yml
+++ b/fips-files/configs/d3d11-win64-clang-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
-platform: win64 
+platform: win64
 generator: Ninja
-build_tool: vscode_ninja
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: windows-clang.cmake
 defines:

--- a/fips-files/configs/d3d11-win64-clang-vscode-release.yml
+++ b/fips-files/configs/d3d11-win64-clang-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
-platform: win64 
+platform: win64
 generator: Ninja
-build_tool: vscode_ninja
+build_tool: vscode
 build_type: Release
 cmake-toolchain: windows-clang.cmake
 defines:

--- a/fips-files/configs/d3d11-win64-vscode-debug.yml
+++ b/fips-files/configs/d3d11-win64-vscode-debug.yml
@@ -1,7 +1,8 @@
 ---
 platform: win64
+generator: Visual Studio 17
 generator-platform: x64
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 defines:
     SOKOL_USE_D3D11: ON

--- a/fips-files/configs/metal-osx-vscode-debug.yml
+++ b/fips-files/configs/metal-osx-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: osx
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 defines:
     SOKOL_USE_METAL: ON

--- a/fips-files/configs/osx-vscode-debug.yml
+++ b/fips-files/configs/osx-vscode-debug.yml
@@ -1,5 +1,5 @@
 ---
 platform: osx
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug

--- a/fips-files/configs/sapp-android-vscode-debug.yml
+++ b/fips-files/configs/sapp-android-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: android
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: android.toolchain.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-android-vscode-release.yml
+++ b/fips-files/configs/sapp-android-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: android
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 cmake-toolchain: android.toolchain.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-d3d11-win64-clang-vscode-debug.yml
+++ b/fips-files/configs/sapp-d3d11-win64-clang-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: win64
 generator: Ninja
-build_tool: vscode_ninja
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: windows-clang.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-d3d11-win64-clang-vscode-release.yml
+++ b/fips-files/configs/sapp-d3d11-win64-clang-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: win64
 generator: Ninja
-build_tool: vscode_ninja
+build_tool: vscode
 build_type: Release
 cmake-toolchain: windows-clang.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-d3d11-win64-vscode-debug.yml
+++ b/fips-files/configs/sapp-d3d11-win64-vscode-debug.yml
@@ -1,7 +1,8 @@
 ---
 platform: win64
+generator: Visual Studio 17
 generator-platform: x64
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-egl-gl-linux-vscode-debug.yml
+++ b/fips-files/configs/sapp-egl-gl-linux-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-egl-gl-linux-vscode-release.yml
+++ b/fips-files/configs/sapp-egl-gl-linux-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-egl-gles3-linux-vscode-debug.yml
+++ b/fips-files/configs/sapp-egl-gles3-linux-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-egl-gles3-linux-vscode-release.yml
+++ b/fips-files/configs/sapp-egl-gles3-linux-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-linux-vscode-debug.yml
+++ b/fips-files/configs/sapp-linux-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-linux-vscode-release.yml
+++ b/fips-files/configs/sapp-linux-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-metal-osx-vscode-debug.yml
+++ b/fips-files/configs/sapp-metal-osx-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: osx
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-osx-vscode-debug.yml
+++ b/fips-files/configs/sapp-osx-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: osx
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-osx-vscode-release.yml
+++ b/fips-files/configs/sapp-osx-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: osx
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/sapp-webgl2-emsc-vscode-release.yml
+++ b/fips-files/configs/sapp-webgl2-emsc-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 cmake-toolchain: emscripten.toolchain.cmake
 defines:

--- a/fips-files/configs/sapp-webgl2-wasm-vscode-debug.yml
+++ b/fips-files/configs/sapp-webgl2-wasm-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: emscripten.toolchain.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-webgl2-wasm-vscode-release.yml
+++ b/fips-files/configs/sapp-webgl2-wasm-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 cmake-toolchain: emscripten.toolchain.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-wgpu-wasm-vscode-debug.yml
+++ b/fips-files/configs/sapp-wgpu-wasm-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: emscripten.toolchain.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-wgpu-wasm-vscode-release.yml
+++ b/fips-files/configs/sapp-wgpu-wasm-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 cmake-toolchain: emscripten.toolchain.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-win64-clang-vscode-debug.yml
+++ b/fips-files/configs/sapp-win64-clang-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: win64
 generator: Ninja
-build_tool: vscode_ninja
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: windows-clang.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-win64-clang-vscode-release.yml
+++ b/fips-files/configs/sapp-win64-clang-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: win64
 generator: Ninja
-build_tool: vscode_ninja
+build_tool: vscode
 build_type: Release
 cmake-toolchain: windows-clang.cmake
 vscode_exclude_from_workspace:

--- a/fips-files/configs/sapp-win64-vscode-debug.yml
+++ b/fips-files/configs/sapp-win64-vscode-debug.yml
@@ -1,7 +1,8 @@
 ---
 platform: win64
+generator: Visual Studio 17
 generator-platform: x64
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 vscode_exclude_from_workspace:
     - fips-glfw

--- a/fips-files/configs/webgl2-emsc-vscode-release.yml
+++ b/fips-files/configs/webgl2-emsc-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 cmake-toolchain: emscripten.toolchain.cmake
 defines:

--- a/fips-files/configs/webgl2-wasm-vscode-debug.yml
+++ b/fips-files/configs/webgl2-wasm-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: emscripten.toolchain.cmake
 defines:

--- a/fips-files/configs/webgl2-wasm-vscode-release.yml
+++ b/fips-files/configs/webgl2-wasm-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 cmake-toolchain: emscripten.toolchain.cmake
 defines:

--- a/fips-files/configs/wgpu-wasm-vscode-debug.yml
+++ b/fips-files/configs/wgpu-wasm-vscode-debug.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Debug
 cmake-toolchain: emscripten.toolchain.cmake
 defines:

--- a/fips-files/configs/wgpu-wasm-vscode-release.yml
+++ b/fips-files/configs/wgpu-wasm-vscode-release.yml
@@ -1,7 +1,7 @@
 ---
 platform: emscripten
 generator: Ninja
-build_tool: vscode_cmake
+build_tool: vscode
 build_type: Release
 cmake-toolchain: emscripten.toolchain.cmake
 defines:


### PR DESCRIPTION
Changes the vscode build configs:
- build_tool 'vscode_cmake' and 'vscode_ninja' have been merged into just 'vscode'
- Windows configs now have an explicit Visual Studio generator set (required because cmake and CMake Tools have different defaults if the generator is missing)