### PR TITLE
Add testing code for new backend-resource access functions.

### DIFF
--- a/d3d11/inject-d3d11.c
+++ b/d3d11/inject-d3d11.c
@@ -85,7 +85,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         16, 17, 18,  16, 18, 19,
         22, 21, 20,  23, 22, 20
     };
-    ID3D11Device* d3d11_dev = (ID3D11Device*) d3d11_get_context().d3d11.device;
+    ID3D11Device* d3d11_dev = (ID3D11Device*) sg_d3d11_device();
     D3D11_BUFFER_DESC d3d11_vbuf_desc = {
         .ByteWidth = sizeof(vertices),
         .Usage = D3D11_USAGE_IMMUTABLE,
@@ -115,11 +115,13 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         .size = sizeof(vertices),
         .d3d11_buffer = d3d11_vbuf
     });
+    assert(sg_d3d11_query_buffer_info(vbuf).buf == d3d11_vbuf);
     sg_buffer ibuf = sg_make_buffer(&(sg_buffer_desc){
         .size = sizeof(indices),
         .type = SG_BUFFERTYPE_INDEXBUFFER,
         .d3d11_buffer = d3d11_ibuf
     });
+    assert(sg_d3d11_query_buffer_info(ibuf).buf == d3d11_ibuf);
 
     // can release the native D3D11 buffers now, sokol_gfx is holding on to them
     d3d11_vbuf->lpVtbl->Release(d3d11_vbuf); d3d11_vbuf = 0;
@@ -161,6 +163,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         .d3d11_texture = d3d11_tex,
         .d3d11_shader_resource_view = d3d11_srv
     });
+    assert(sg_d3d11_query_image_info(img).tex2d == d3d11_tex);
+    assert(sg_d3d11_query_image_info(img).tex3d == 0);
+    assert(sg_d3d11_query_image_info(img).res == d3d11_tex);
+    assert(sg_d3d11_query_image_info(img).srv == d3d11_srv);
     if (d3d11_tex) {
         d3d11_tex->lpVtbl->Release(d3d11_tex);
         d3d11_tex = 0;
@@ -191,6 +197,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         .wrap_v = SG_WRAP_REPEAT,
         .d3d11_sampler = d3d11_smp,
     });
+    assert(sg_d3d11_query_sampler_info(smp).smp == d3d11_smp);
     d3d11_smp->lpVtbl->Release(d3d11_smp); d3d11_smp = 0;
 
     // create shader
@@ -232,6 +239,11 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
                 "}\n"
         },
     });
+    assert(sg_d3d11_query_shader_info(shd).vs != 0);
+    assert(sg_d3d11_query_shader_info(shd).fs != 0);
+    assert(sg_d3d11_query_shader_info(shd).vs_cbufs[0] != 0);
+    assert(sg_d3d11_query_shader_info(shd).vs_cbufs[1] == 0);
+    assert(sg_d3d11_query_shader_info(shd).fs_cbufs[0] == 0);
 
     // pipeline object
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
@@ -249,6 +261,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         },
         .cull_mode = SG_CULLMODE_BACK,
     });
+    assert(sg_d3d11_query_pipeline_info(pip).il != 0);
+    assert(sg_d3d11_query_pipeline_info(pip).rs != 0);
+    assert(sg_d3d11_query_pipeline_info(pip).dss != 0);
+    assert(sg_d3d11_query_pipeline_info(pip).bs != 0);
 
     // default pass action (clear to gray)
     sg_pass_action pass_action = { 0 };

--- a/d3d11/mipmap-d3d11.c
+++ b/d3d11/mipmap-d3d11.c
@@ -120,8 +120,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     // the last 4 samplers use different anistropy levels
     smp_desc.min_lod = 0.0f;
     smp_desc.max_lod = 0.0f;    // for max_lod, zero-initialized means "FLT_MAX"
-    smp_desc.min_filter = SG_FILTER_NEAREST;
-    smp_desc.mag_filter = SG_FILTER_NEAREST;
+    smp_desc.min_filter = SG_FILTER_LINEAR;
+    smp_desc.mag_filter = SG_FILTER_LINEAR;
     smp_desc.mipmap_filter = SG_FILTER_LINEAR;
     for (int i = 0; i < 4; i++) {
         smp_desc.max_anisotropy = 1<<i;

--- a/d3d11/offscreen-d3d11.c
+++ b/d3d11/offscreen-d3d11.c
@@ -43,6 +43,10 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
         .color_attachments[0].image = color_img,
         .depth_stencil_attachment.image = depth_img
     });
+    assert(sg_d3d11_query_pass_info(offscreen_pass).color_rtv[0] != 0);
+    assert(sg_d3d11_query_pass_info(offscreen_pass).color_rtv[1] == 0);
+    assert(sg_d3d11_query_pass_info(offscreen_pass).resolve_rtv[0] == 0);
+    assert(sg_d3d11_query_pass_info(offscreen_pass).dsv != 0);
 
     // a sampler object for when the rendertarget image is used as texture
     sg_sampler smp = sg_make_sampler(&(sg_sampler_desc){

--- a/glfw/inject-glfw.c
+++ b/glfw/inject-glfw.c
@@ -102,12 +102,18 @@ int main() {
         .size = sizeof(vertices),
         .gl_buffers[0] = gl_vbuf
     });
+    assert(sg_gl_query_buffer_info(vbuf).buf[0] == gl_vbuf);
+    assert(sg_gl_query_buffer_info(vbuf).buf[1] == 0);
+    assert(sg_gl_query_buffer_info(vbuf).active_slot == 0);
     sg_buffer ibuf = sg_make_buffer(&(sg_buffer_desc){
         .type = SG_BUFFERTYPE_INDEXBUFFER,
         .usage = SG_USAGE_IMMUTABLE,
         .size = sizeof(indices),
         .gl_buffers[0] = gl_ibuf
     });
+    assert(sg_gl_query_buffer_info(ibuf).buf[0] == gl_ibuf);
+    assert(sg_gl_query_buffer_info(ibuf).buf[1] == 0);
+    assert(sg_gl_query_buffer_info(ibuf).active_slot == 0);
 
     /* create dynamically updated textures, in the GL backend
        dynamic textures are rotated through, so need to create
@@ -129,6 +135,11 @@ int main() {
     }
     sg_reset_state_cache();
     sg_image img = sg_make_image(&img_desc);
+    assert(sg_gl_query_image_info(img).tex[0] == img_desc.gl_textures[0]);
+    assert(sg_gl_query_image_info(img).tex[1] == img_desc.gl_textures[1]);
+    assert(sg_gl_query_image_info(img).active_slot == 0);
+    assert(sg_gl_query_image_info(img).tex_target == GL_TEXTURE_2D);
+    assert(sg_gl_query_image_info(img).msaa_render_buffer == 0);
 
     // create a GL sampler object
     sg_sampler_desc smp_desc = {
@@ -144,6 +155,7 @@ int main() {
     glSamplerParameteri(smp_desc.gl_sampler, GL_TEXTURE_WRAP_T, GL_REPEAT);
     sg_reset_state_cache();
     sg_sampler smp = sg_make_sampler(&smp_desc);
+    assert(sg_gl_query_sampler_info(smp).smp == smp_desc.gl_sampler);
 
     // define resource bindings
     sg_bindings bind = {
@@ -186,6 +198,7 @@ int main() {
                 "}\n"
         }
     });
+    assert(sg_gl_query_shader_info(shd).prog != 0);
 
     // create pipeline object
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){

--- a/glfw/offscreen-glfw.c
+++ b/glfw/offscreen-glfw.c
@@ -53,6 +53,8 @@ int main() {
         .color_attachments[0].image = color_img,
         .depth_stencil_attachment.image = depth_img
     });
+    assert(sg_gl_query_pass_info(offscreen_pass).frame_buffer != 0);
+    assert(sg_gl_query_pass_info(offscreen_pass).msaa_resolve_framebuffer[0] == 0);
 
     // pass action for offscreen pass, clearing to black
     sg_pass_action offscreen_pass_action = {

--- a/metal/inject-metal.mm
+++ b/metal/inject-metal.mm
@@ -99,12 +99,16 @@ static void init(void) {
         .mtl_buffers[0] = (__bridge const void*) mtl_vbuf
     };
     state.bind.vertex_buffers[0] = sg_make_buffer(&vbuf_desc);
+    assert(((__bridge id<MTLBuffer>) sg_mtl_query_buffer_info(state.bind.vertex_buffers[0]).buf[0]) == mtl_vbuf);
+    assert(((__bridge id<MTLBuffer>) sg_mtl_query_buffer_info(state.bind.vertex_buffers[0]).buf[1]) == nil);
     sg_buffer_desc ibuf_desc = {
         .type = SG_BUFFERTYPE_INDEXBUFFER,
         .size = sizeof(indices),
         .mtl_buffers[0] = (__bridge const void*) mtl_ibuf
     };
     state.bind.index_buffer = sg_make_buffer(&ibuf_desc);
+    assert(((__bridge id<MTLBuffer>) sg_mtl_query_buffer_info(state.bind.index_buffer).buf[0]) == mtl_ibuf);
+    assert(((__bridge id<MTLBuffer>) sg_mtl_query_buffer_info(state.bind.index_buffer).buf[1]) == nil);
 
     // create dynamically updated Metal texture objects, these will
     // be rotated through by sokol_gfx as they are updated, so we need
@@ -131,6 +135,8 @@ static void init(void) {
 
     sg_reset_state_cache();
     state.bind.fs.images[0] = sg_make_image(&img_desc);
+    assert(((__bridge id<MTLTexture>) sg_mtl_query_image_info(state.bind.fs.images[0]).tex[0]) == mtl_tex[0]);
+    assert(((__bridge id<MTLTexture>) sg_mtl_query_image_info(state.bind.fs.images[0]).tex[1]) == mtl_tex[1]);
 
     // create a Metal sampler object and inject into a sokol-gfx sampler object
     MTLSamplerDescriptor* mtl_smp_desc = [[MTLSamplerDescriptor alloc] init];
@@ -150,6 +156,7 @@ static void init(void) {
 
     sg_reset_state_cache();
     state.bind.fs.samplers[0] = sg_make_sampler(&smp_desc);
+    assert(((__bridge id<MTLSamplerState>) sg_mtl_query_sampler_info(state.bind.fs.samplers[0]).smp) == mtl_smp);
 
     // a shader
     sg_shader_desc shader_desc = {
@@ -197,6 +204,10 @@ static void init(void) {
         }
     };
     sg_shader shd = sg_make_shader(&shader_desc);
+    assert(((__bridge id<MTLLibrary>) sg_mtl_query_shader_info(shd).vs_lib) != nil);
+    assert(((__bridge id<MTLLibrary>) sg_mtl_query_shader_info(shd).fs_lib) != nil);
+    assert(((__bridge id<MTLFunction>) sg_mtl_query_shader_info(shd).vs_func) != nil);
+    assert(((__bridge id<MTLFunction>) sg_mtl_query_shader_info(shd).fs_func) != nil);
 
     // a pipeline state object
     sg_pipeline_desc pip_desc = {
@@ -215,6 +226,8 @@ static void init(void) {
         .cull_mode = SG_CULLMODE_BACK,
     };
     state.pip = sg_make_pipeline(&pip_desc);
+    assert(((__bridge id<MTLRenderPipelineState>) sg_mtl_query_pipeline_info(state.pip).rps) != nil);
+    assert(((__bridge id<MTLDepthStencilState>) sg_mtl_query_pipeline_info(state.pip).dss) != nil);
 
     // view-projection matrix
     hmm_mat4 proj = HMM_Perspective(60.0f, (float)WIDTH/(float)HEIGHT, 0.01f, 10.0f);

--- a/wgpu/offscreen-wgpu.c
+++ b/wgpu/offscreen-wgpu.c
@@ -72,6 +72,10 @@ static void init(void) {
         .color_attachments[0].image = color_img,
         .depth_stencil_attachment.image = depth_img
     });
+    assert(sg_wgpu_query_pass_info(state.offscreen.pass).color_view[0] != 0);
+    assert(sg_wgpu_query_pass_info(state.offscreen.pass).color_view[1] == 0);
+    assert(sg_wgpu_query_pass_info(state.offscreen.pass).resolve_view[0] == 0);
+    assert(sg_wgpu_query_pass_info(state.offscreen.pass).ds_view != 0);
 
     // a sampler object for when the render target is used as texture
     sg_sampler smp = sg_make_sampler(&(sg_sampler_desc){


### PR DESCRIPTION
This just adds a couple of asserts to the platform-specific samples to test the new backend-resource-access functions.

...also fixes the mipmap-d3d11 sample which was missing a fix for earlier validation layer updates.