### PR TITLE
readme fix: glfw build example on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ To build one of the GLFW samples on Linux:
 
 ```sh
 > cd sokol-samples/glfw
-> cc cube-glfw.c flextgl/flextGL.c -o cube-glfw -I../../sokol -lGL -ldl -lm -lglfw3
+> cc cube-glfw.c glfw_glue.c flextgl/flextGL.c -o cube-glfw -I../../sokol -lGL -ldl -lm -lglfw3
 ```
 
 To build one of the sokol-app samples on Linux:


### PR DESCRIPTION
minor docfix, glfw_glue.c is needed to build