### PR TITLE
Changes for sokol-gfx write-unsealed feature.

### DIFF
--- a/fibs-scripts/sapp.ts
+++ b/fibs-scripts/sapp.ts
@@ -78,6 +78,7 @@ export const samples: SampleOptions[] = [
         deps: ['imgui', 'fileutil', 'basisu'],
         jobs: [copy('data/texview', ['kodim05.basis', 'kodim07.basis', 'kodim17.basis', 'kodim20.basis', 'kodim23.basis' ])],
     },
+    { name: 'writeimage', shd: true, deps: ['imgui'] },
     { name: 'letterbox', deps: ['imgui'] },
     { name: 'framebuffer', ui: 'cc' },
     {

--- a/sapp/cubemap-jpeg-sapp.c
+++ b/sapp/cubemap-jpeg-sapp.c
@@ -1,7 +1,8 @@
 //------------------------------------------------------------------------------
 //  cubemap-jpeg-sapp.c
 //
-//  Load and render cubemap from individual jpeg files.
+//  Load and render cubemap from individual jpeg files. Also demonstrates
+//  how to incrementally populate an image via sg_write_image_unsealed()
 //------------------------------------------------------------------------------
 #define VECMATH_GENERICS
 #include "vecmath/vecmath.h"
@@ -21,32 +22,22 @@
 
 static struct {
     sg_pass_action pass_action;
+    sg_image img;
     sg_pipeline pip;
     sg_bindings bind;
     camera_t camera;
     int load_count;
     bool load_failed;
-    sg_range pixels;
 } state;
 
-// room for loading all cubemap faces in parallel
 #define NUM_FACES (6)
 #define FACE_WIDTH (2048)
 #define FACE_HEIGHT (2048)
 #define FACE_NUM_BYTES (FACE_WIDTH * FACE_HEIGHT * 4)
 
-static void fetch_cb(const sfetch_response_t*);
+static uint8_t iobuffer[FACE_NUM_BYTES];
 
-static sg_range cubeface_range(int face_index) {
-    assert(state.pixels.ptr);
-    assert((face_index >= 0) && (face_index < NUM_FACES));
-    size_t offset = (size_t)(face_index * FACE_NUM_BYTES);
-    assert((offset + FACE_NUM_BYTES) <= state.pixels.size);
-    return (sg_range){
-        .ptr = ((uint8_t*)state.pixels.ptr) + offset,
-        .size = FACE_NUM_BYTES
-    };
-}
+static void fetch_cb(const sfetch_response_t*);
 
 static void init(void) {
 
@@ -61,11 +52,13 @@ static void init(void) {
         .logger.func = slog_func,
     });
 
-    // setup sokol-fetch to load 6 faces in parallel
+    // setup sokol-fetch, restrict to one download at a time
+    // to preserve memory and demonstrate writing individual
+    // cubemap faces vis sg_write_image_unsealed()
     sfetch_setup(&(sfetch_desc_t){
         .max_requests = 6,
         .num_channels = 1,
-        .num_lanes = NUM_FACES,
+        .num_lanes = 1,
         .logger.func = slog_func,
     });
 
@@ -77,11 +70,6 @@ static void init(void) {
         .min_dist = 0.1f,
         .max_dist = 0.1f,
     });
-
-    // allocate memory for pixel data (both as io buffer for JPEG data, and for the decoded pixel data)
-    state.pixels.size = NUM_FACES * FACE_NUM_BYTES;
-    state.pixels.ptr = malloc(state.pixels.size);
-    assert(state.pixels.ptr);
 
     // pass action, clear to black
     state.pass_action = (sg_pass_action){
@@ -138,11 +126,21 @@ static void init(void) {
         .label = "cubemap-indices"
     });
 
-    // allocate a (texture) view handle, but only initialize it later once the
-    // texture data has been asynchronously loaded, this allows us to write
-    // a regular render loop without having to explicitly skip rendering as
-    // long as the texture isn't loaded yet
-    state.bind.views[VIEW_tex] = sg_alloc_view();
+    // create cubemap image without initial content in unsealed state
+    state.img = sg_make_image(&(sg_image_desc){
+        .usage.write_unsealed = true,
+        .type = SG_IMAGETYPE_CUBE,
+        .width = FACE_WIDTH,
+        .height = FACE_HEIGHT,
+        .pixel_format = SG_PIXELFORMAT_RGBA8,
+        .label = "cubemap-image",
+    });
+
+    // create texture view for the cubemap image
+    state.bind.views[VIEW_tex] = sg_make_view(&(sg_view_desc){
+        .texture = { .image = state.img },
+        .label = "cubemap-view",
+    });
 
     // a sampler object
     state.bind.samplers[SMP_smp] = sg_make_sampler(&(sg_sampler_desc){
@@ -163,18 +161,21 @@ static void init(void) {
         .label = "cubemap-pipeline",
     });
 
-    // load 6 cubemap face image files (note: filenames are in same order as SG_CUBEFACE_*)
+    // start loading the six cubemap face image files, note that the loading
+    // will be throttled to happen in sequence by sokol-fetch, that way it's
+    // safe to reuse the same iobuffer for each image
     char path_buf[1024];
     const char* filenames[NUM_FACES] = {
         "nb2_posx.jpg", "nb2_negx.jpg",
         "nb2_posy.jpg", "nb2_negy.jpg",
         "nb2_posz.jpg", "nb2_negz.jpg"
     };
-    for (int i = 0; i < NUM_FACES; i++) {
+    for (int face_index = 0; face_index < NUM_FACES; face_index++) {
         sfetch_send(&(sfetch_request_t){
-            .path = fileutil_get_path(filenames[i], path_buf, sizeof(path_buf)),
+            .path = fileutil_get_path(filenames[face_index], path_buf, sizeof(path_buf)),
             .callback = fetch_cb,
-            .buffer = { .ptr = cubeface_range(i).ptr, .size = cubeface_range(i).size },
+            .buffer = SFETCH_RANGE(iobuffer),
+            .user_data = SFETCH_RANGE(face_index),
         });
     }
 }
@@ -192,26 +193,36 @@ static void fetch_cb(const sfetch_response_t* response) {
         if (decoded_pixels) {
             assert(width == FACE_WIDTH);
             assert(height == FACE_HEIGHT);
-            // overwrite JPEG data with decoded pixel data
-            memcpy((void*)response->buffer.ptr, decoded_pixels, FACE_NUM_BYTES);
-            stbi_image_free(decoded_pixels);
-            // all 6 faces loaded?
-            if (++state.load_count == NUM_FACES) {
-                // create a cubemap image
-                sg_image img = sg_make_image(&(sg_image_desc){
-                    .type = SG_IMAGETYPE_CUBE,
+
+            // get the cubeface index from response's userdata
+            assert(response->user_data);
+            int face_index = *(int*)response->user_data;
+
+            // write the cubeface data into the image
+            sg_write_image_unsealed(&(sg_write_image_desc){
+                // note: src.bytes_per_row and src.rows_per_slice can remain
+                // at default zero because the in-memory data is already in the right layout
+                .src.data = {
+                    .ptr = decoded_pixels,
+                    .size = FACE_NUM_BYTES
+                },
+                .dst = {
+                    .image = state.img,
+                    .mip_level = 0,
+                    .slice = face_index
+                },
+                // FIXME: test with width = 0, height = 0
+                .size = {
                     .width = width,
                     .height = height,
-                    .pixel_format = SG_PIXELFORMAT_RGBA8,
-                    .data.mip_levels[0] = state.pixels,
-                    .label = "cubemap-image",
-                });
-                free((void*)state.pixels.ptr); state.pixels.ptr = 0;
-                // ...and initialize the pre-allocated view
-                sg_init_view(state.bind.views[VIEW_tex], &(sg_view_desc){
-                    .texture = { .image = img },
-                    .label = "cubemap-view",
-                });
+                    .num_slices = 1,
+                },
+            });
+            stbi_image_free(decoded_pixels);
+
+            // when all 6 cube faces have been loaded, seal the image
+            if (++state.load_count == NUM_FACES) {
+                sg_seal_image(state.img);
             }
         }
     } else if (response->failed) {
@@ -237,6 +248,8 @@ static void frame(void) {
         sdtx_puts("LMB + move mouse to look around");
     }
 
+    // NOTE: as long as the image is in unsealed state (e.g. data is still loading)
+    // all render operations involving the image will silently be skipped
     sg_begin_pass(&(sg_pass){ .action = state.pass_action, .swapchain = sglue_swapchain() });
     sg_apply_pipeline(state.pip);
     sg_apply_bindings(&state.bind),

--- a/sapp/cubemap-jpeg-sapp.c
+++ b/sapp/cubemap-jpeg-sapp.c
@@ -209,14 +209,15 @@ static void fetch_cb(const sfetch_response_t* response) {
                 .dst = {
                     .image = state.img,
                     .mip_level = 0,
-                    .slice = face_index
+                    .slice = face_index,
                 },
-                // FIXME: test with width = 0, height = 0
+                // note: when default width and height are zero-initialized, the
+                // sizes will be inferred from the image, num_slices must be
+                // explicitly set to 1 in this scenario, because the inferred
+                // number of slices for a cubemap would be 6
                 .size = {
-                    .width = width,
-                    .height = height,
                     .num_slices = 1,
-                },
+                }
             });
             stbi_image_free(decoded_pixels);
 

--- a/sapp/vertexindexbuffer-sapp.c
+++ b/sapp/vertexindexbuffer-sapp.c
@@ -3,6 +3,8 @@
 //
 //  A variant of cube-sapp which puts vertices and indices into the same
 //  buffer (which isn't allowed on WebGL2, but fine on other APIs).
+//  Also tests/demonstrates using sg_write_buffer_unsealed() to populate
+//  a buffer before usage.
 //------------------------------------------------------------------------------
 #define VECMATH_GENERICS
 #include "vecmath/vecmath.h"
@@ -90,21 +92,27 @@ static void init(void) {
     };
 
     // create a buffer with both vertices and indices
-    const size_t buf_size = sizeof(vertices) + sizeof(indices);
     const size_t indices_offset = sizeof(vertices);
-    uint8_t* data_ptr = malloc(buf_size);
-    memcpy(data_ptr, vertices, sizeof(vertices));
-    memcpy(data_ptr + indices_offset, indices, sizeof(indices));
     sg_buffer buf = sg_make_buffer(&(sg_buffer_desc){
-        // indicate that this buffer is going to be bound as vertex- and index-buffer
+        // indicate that this buffer is going to be bound as vertex- and index-buffer,
+        // and that it will be populated via sg_write_buffer_unsealed() after creation
         .usage = {
             .vertex_buffer = true,
             .index_buffer = true,
+            .write_unsealed = true,
         },
-        .data = { .ptr = data_ptr, .size = buf_size },
+        .size = sizeof(vertices) + sizeof(indices),
         .label = "vertex-index-buffer",
     });
-    free(data_ptr);
+    sg_write_buffer_unsealed(&(sg_write_buffer_desc){
+        .src.data = SG_RANGE(vertices),
+        .dst = { .buffer = buf, .offset = 0 },
+    });
+    sg_write_buffer_unsealed(&(sg_write_buffer_desc){
+        .src.data = SG_RANGE(indices),
+        .dst = { .buffer = buf, .offset = indices_offset },
+    });
+    sg_seal_buffer(buf);
 
     // setup the resource bindings, the same buffer is bound as
     // vertex- and index-buffer, with the index data starting at an offset

--- a/sapp/writeimage-sapp.c
+++ b/sapp/writeimage-sapp.c
@@ -55,6 +55,7 @@ static struct {
             } size;
         } write;
         struct {
+            int mip_level;
             int slice;
         } display;
     } ui;
@@ -117,6 +118,7 @@ static int ui_mip_dim(int base, int mip_level) {
 static void ui_update_deps(bool img_type_changed) {
     state.ui.write.dirty = true;
     if (img_type_changed) {
+        state.ui.display.mip_level = 0;
         state.ui.display.slice = 0;
     }
 
@@ -219,6 +221,7 @@ static void ui(void) {
     igSetNextWindowBgAlpha(0.75f);
     if (igBegin("Controls", 0, ImGuiWindowFlags_NoDecoration|ImGuiWindowFlags_AlwaysAutoResize)) {
         igSeparatorText("Display Options");
+        igSliderInt("Mip Level##display", &state.ui.display.mip_level, 0, IMG_NUM_MIPMAPS - 1);
         igSliderInt("Slice##display", &state.ui.display.slice, 0, state.ui.max_slice);
         igSeparatorText("Write Options");
         if (igComboChar("Image Type", &state.ui.image_type, imgtype_str, IM_ARRAYSIZE(imgtype_str))) {
@@ -240,7 +243,7 @@ static void ui(void) {
         }
         igEndDisabled();
         igText("Write Destination:");
-        if (igSliderInt("Mip Level", &state.ui.write.dst.mip_level, 0, IMG_NUM_MIPMAPS)) {
+        if (igSliderInt("Mip Level##dst", &state.ui.write.dst.mip_level, 0, IMG_NUM_MIPMAPS)) {
             ui_update_deps(false);
         }
         if (igSliderInt("X", &state.ui.write.dst.x, 0, state.ui.max_x)) {
@@ -249,7 +252,7 @@ static void ui(void) {
         if (igSliderInt("Y", &state.ui.write.dst.y, 0, state.ui.max_y)) {
             ui_update_deps(false);
         }
-        if (igSliderInt("Slice##write", &state.ui.write.dst.slice, 0, state.ui.max_slice)) {
+        if (igSliderInt("Slice##dst", &state.ui.write.dst.slice, 0, state.ui.max_slice)) {
             ui_update_deps(false);
         }
         igText("Write Size:");

--- a/sapp/writeimage-sapp.c
+++ b/sapp/writeimage-sapp.c
@@ -1,0 +1,260 @@
+//------------------------------------------------------------------------------
+//  writeimage-sapp.c
+//
+//  Test the new sg_write_image_* functions.
+//------------------------------------------------------------------------------
+#include "sokol_app.h"
+#include "sokol_gfx.h"
+#include "sokol_log.h"
+#include "sokol_glue.h"
+#define SOKOL_LETTERBOX_IMPL
+#include "sokol_letterbox.h"
+#include "cimgui.h"
+#define SOKOL_IMGUI_IMPL
+#include "sokol_imgui.h"
+#define SOKOL_GFX_IMGUI_IMPL
+#include "sokol_gfx_imgui.h"
+#define SOKOL_APP_IMGUI_IMPL
+#include "sokol_app_imgui.h"
+#include "writeimage-sapp.glsl.h"
+
+#define IMG_NUM_MIPMAPS (8)
+#define IMG_WIDTH (1 << IMG_NUM_MIPMAPS)
+#define IMG_HEIGHT (1 << IMG_NUM_MIPMAPS)
+#define IMG_NUM_SLICES (6)
+#define IMG_BYTES_PER_PIXEL (4)
+
+typedef enum { IMGTYPE_2D, IMGTYPE_CUBE, IMGTYPE_3D, IMGTYPE_ARRAY, NUM_IMGTYPES } image_type_t;
+static const char* imgtype_str[] = { "2D", "Cube Map", "3D", "2D Array" };
+
+static struct {
+    sg_pipeline pips[NUM_IMGTYPES];
+    struct {
+        int image_type; // image_type_t
+        int max_x, max_y, max_slice;
+        int max_width, max_height, max_num_slices;
+        struct {
+            bool dirty;
+            struct {
+                int offset;
+                bool use_defaults;
+                int bytes_per_row;
+                int bytes_per_slice;
+            } src;
+            struct {
+                int mip_level;
+                int x, y, slice;
+            } dst;
+            struct {
+                bool use_defaults;
+                int width, height, num_slices;
+            } size;
+        } write;
+        struct {
+            int slice;
+        } display;
+    } ui;
+} state = {
+    .ui.write.src.use_defaults = true,
+    .ui.write.size.use_defaults = true,
+};
+
+static void ui(void);
+static void ui_update_deps(bool img_type_changed);
+
+static void init(void) {
+    sg_setup(&(sg_desc){
+        .environment = sglue_environment(),
+        .logger.func = slog_func,
+    });
+    sgimgui_setup(&(sgimgui_desc_t){0});
+    sappimgui_setup();
+    simgui_setup(&(simgui_desc_t){
+        .logger.func = slog_func,
+    });
+    ui_update_deps(true);
+    state.ui.write.dirty = false;
+}
+
+static void frame(void) {
+    ui();
+
+    sg_begin_pass(&(sg_pass){ .swapchain = sglue_swapchain() });
+    simgui_render();
+    sg_end_pass();
+    sg_commit();
+
+}
+
+static void input(const sapp_event* ev) {
+    sappimgui_track_event(ev);
+    simgui_handle_event(ev);
+}
+
+static void cleanup(void) {
+    sappimgui_shutdown();
+    sgimgui_shutdown();
+    simgui_shutdown();
+    sg_shutdown();
+}
+
+static int ui_max(int v0, int v1) {
+    return (v0 > v1) ? v0 : v1;
+}
+
+static int ui_min(int v0, int v1) {
+    return (v0 < v1) ? v0 : v1;
+}
+
+static int ui_mip_dim(int base, int mip_level) {
+    return ui_max(base >> mip_level, 1);
+}
+
+static void ui_update_deps(bool img_type_changed) {
+    state.ui.write.dirty = true;
+    if (img_type_changed) {
+        state.ui.display.slice = 0;
+    }
+
+    // compute current max dst location values
+    const int mip_level = state.ui.write.dst.mip_level;
+    const int mip_width = ui_mip_dim(IMG_WIDTH, mip_level);
+    const int mip_height = ui_mip_dim(IMG_HEIGHT, mip_level);
+    const int mip_depth = ui_mip_dim(IMG_NUM_SLICES, mip_level);
+    state.ui.max_x = mip_width - 1;
+    state.ui.max_y = mip_height - 1;
+    switch (state.ui.image_type) {
+        case IMGTYPE_2D:
+            state.ui.max_slice = 0;
+            break;
+        case IMGTYPE_3D:
+            state.ui.max_slice = mip_depth - 1;
+            break;
+        default:
+            state.ui.max_slice = IMG_NUM_SLICES - 1;
+            break;
+    }
+
+    // clamp dst location values
+    state.ui.write.dst.x = ui_min(state.ui.write.dst.x, state.ui.max_x);
+    state.ui.write.dst.y = ui_min(state.ui.write.dst.y, state.ui.max_y);
+    state.ui.write.dst.slice = ui_min(state.ui.write.dst.slice, state.ui.max_slice);
+
+    // compute max size values
+    state.ui.max_width = mip_width - state.ui.write.dst.x;
+    state.ui.max_height = mip_height - state.ui.write.dst.y;
+    switch (state.ui.image_type) {
+        case IMGTYPE_2D:
+            state.ui.max_num_slices = 1;
+            break;
+        case IMGTYPE_3D:
+            state.ui.max_num_slices = mip_depth - state.ui.write.dst.slice;
+            break;
+        default:
+            state.ui.max_num_slices = IMG_NUM_SLICES - state.ui.write.dst.slice;
+            break;
+    }
+
+    // clamp size values
+    if (state.ui.write.size.use_defaults || img_type_changed) {
+        state.ui.write.size.width = state.ui.max_width;
+        state.ui.write.size.height = state.ui.max_height;
+        state.ui.write.size.num_slices = state.ui.max_num_slices;
+    } else {
+        state.ui.write.size.width = ui_min(state.ui.write.size.width, state.ui.max_width);
+        state.ui.write.size.height = ui_min(state.ui.write.size.height, state.ui.max_height);
+        state.ui.write.size.num_slices = ui_min(state.ui.write.size.num_slices, state.ui.max_num_slices);
+    }
+}
+
+static void ui(void) {
+    sappimgui_track_frame();
+    simgui_new_frame(&(simgui_frame_desc_t){
+        .width = sapp_width(),
+        .height = sapp_height(),
+        .dpi_scale = sapp_dpi_scale(),
+        .delta_time = sapp_frame_duration(),
+    });
+    if (igBeginMainMenuBar()) {
+        sgimgui_draw_menu("sokol-gfx");
+        sappimgui_draw_menu("sokol-app");
+        igEndMainMenuBar();
+    }
+    sappimgui_draw();
+    sgimgui_draw();
+    igSetNextWindowPos((ImVec2){ 30, 50 }, ImGuiCond_Once);
+    igSetNextWindowBgAlpha(0.75f);
+    if (igBegin("Controls", 0, ImGuiWindowFlags_NoDecoration|ImGuiWindowFlags_AlwaysAutoResize)) {
+        igSeparatorText("Display Options");
+        igSliderInt("Slice##display", &state.ui.display.slice, 0, state.ui.max_slice);
+        igSeparatorText("Write Options");
+        if (igComboChar("Image Type", &state.ui.image_type, imgtype_str, IM_ARRAYSIZE(imgtype_str))) {
+            ui_update_deps(true);
+        }
+        igText("Write Source:");
+        if (igSliderInt("Offset:", &state.ui.write.src.offset, 0, 1024)) {
+            // must be multiple of bytes-per-pixel
+            state.ui.write.src.offset &= ~(IMG_BYTES_PER_PIXEL-1);
+            ui_update_deps(false);
+        }
+        igText("  FIXME: Bytes Per Row");
+        igText("  FIXME: Bytes Per Slice");
+        igText("Write Destination:");
+        if (igSliderInt("Mip Level", &state.ui.write.dst.mip_level, 0, IMG_NUM_MIPMAPS)) {
+            ui_update_deps(false);
+        }
+        if (igSliderInt("X", &state.ui.write.dst.x, 0, state.ui.max_x)) {
+            ui_update_deps(false);
+        }
+        if (igSliderInt("Y", &state.ui.write.dst.y, 0, state.ui.max_y)) {
+            ui_update_deps(false);
+        }
+        if (igSliderInt("Slice##write", &state.ui.write.dst.slice, 0, state.ui.max_slice)) {
+            ui_update_deps(false);
+        }
+        igText("Write Size:");
+        if (igCheckbox("Use Defaults##sizes", &state.ui.write.size.use_defaults)) {
+            ui_update_deps(false);
+        }
+        igBeginDisabled(state.ui.write.size.use_defaults);
+        if (igSliderInt("Width", &state.ui.write.size.width, 1, state.ui.max_width)) {
+            ui_update_deps(false);
+        }
+        if (igSliderInt("Height", &state.ui.write.size.height, 1, state.ui.max_height)) {
+            ui_update_deps(false);
+        }
+        if (igSliderInt("Num Slices", &state.ui.write.size.num_slices, 1, state.ui.max_num_slices)) {
+            ui_update_deps(false);
+        }
+        igEndDisabled();
+        igBeginDisabled(!state.ui.write.dirty);
+        const bool dirty = state.ui.write.dirty;
+        if (dirty) {
+            igPushStyleColorImVec4(ImGuiCol_Button, (ImVec4){ 1.0f, 0.0f, 0.0f, 1.0f });
+        }
+        if (igButton("Apply Changes")) {
+            state.ui.write.dirty = false;
+            // FIXME: recreate image
+        }
+        if (dirty) {
+            igPopStyleColor();
+        }
+        igEndDisabled();
+    }
+    igEnd();
+}
+
+sapp_desc sokol_main(int argc, char* argv[]) {
+    (void)argc; (void)argv;
+    return (sapp_desc){
+        .init_cb = init,
+        .frame_cb = frame,
+        .cleanup_cb = cleanup,
+        .event_cb = input,
+        .width = 800,
+        .height = 600,
+        .window_title = "writeimage-sapp.c",
+        .icon.sokol_default = true,
+        .logger.func = slog_func,
+    };
+}

--- a/sapp/writeimage-sapp.c
+++ b/sapp/writeimage-sapp.c
@@ -31,6 +31,10 @@ static struct {
     sg_pipeline pips[NUM_IMGTYPES];
     struct {
         int image_type; // image_type_t
+        int min_bytes_per_row;
+        int max_bytes_per_row;
+        int min_bytes_per_slice;
+        int max_bytes_per_slice;
         int max_x, max_y, max_slice;
         int max_width, max_height, max_num_slices;
         struct {
@@ -165,6 +169,35 @@ static void ui_update_deps(bool img_type_changed) {
         state.ui.write.size.height = ui_min(state.ui.write.size.height, state.ui.max_height);
         state.ui.write.size.num_slices = ui_min(state.ui.write.size.num_slices, state.ui.max_num_slices);
     }
+
+    // fix up src options
+    state.ui.min_bytes_per_row = state.ui.max_width * IMG_BYTES_PER_PIXEL;
+    state.ui.max_bytes_per_row = 2048;
+    if (state.ui.write.src.use_defaults) {
+        state.ui.write.src.bytes_per_row = state.ui.min_bytes_per_row;
+    } else {
+        const int min_bpr = state.ui.min_bytes_per_row;
+        const int max_bpr = state.ui.max_bytes_per_row;
+        state.ui.write.src.bytes_per_row = ui_max(ui_min(state.ui.write.src.bytes_per_row, max_bpr), min_bpr);
+    }
+    // offset and bytes-per-row must be multiple of pixel size
+    const int bpp_mask = ~(IMG_BYTES_PER_PIXEL - 1);
+    state.ui.write.src.offset &= bpp_mask;
+    state.ui.write.src.bytes_per_row &= bpp_mask;
+
+    // NOTE: fix up bytes-per-slice *after* bytes-per-row has been fixed
+    const int bpr = state.ui.write.src.bytes_per_row;
+    state.ui.min_bytes_per_slice = bpr * state.ui.max_height;
+    state.ui.max_bytes_per_slice = bpr * 2048;
+    if (state.ui.write.src.use_defaults) {
+        state.ui.write.src.bytes_per_slice = state.ui.min_bytes_per_slice;
+    } else {
+        const int min_bps = state.ui.min_bytes_per_slice;
+        const int max_bps = state.ui.max_bytes_per_slice;
+        state.ui.write.src.bytes_per_slice = ui_max(ui_min(state.ui.write.src.bytes_per_slice, max_bps), min_bps);
+    }
+    // bytes per slice must be a multiple of bytes per row
+    state.ui.write.src.bytes_per_slice = (state.ui.write.src.bytes_per_slice / bpr) * bpr;
 }
 
 static void ui(void) {
@@ -193,12 +226,19 @@ static void ui(void) {
         }
         igText("Write Source:");
         if (igSliderInt("Offset:", &state.ui.write.src.offset, 0, 1024)) {
-            // must be multiple of bytes-per-pixel
-            state.ui.write.src.offset &= ~(IMG_BYTES_PER_PIXEL-1);
             ui_update_deps(false);
         }
-        igText("  FIXME: Bytes Per Row");
-        igText("  FIXME: Bytes Per Slice");
+        if (igCheckbox("Use Defaults##pitch", &state.ui.write.src.use_defaults)) {
+            ui_update_deps(false);
+        }
+        igBeginDisabled(state.ui.write.src.use_defaults);
+        if (igSliderInt("Bytes Per Row", &state.ui.write.src.bytes_per_row, state.ui.min_bytes_per_row, state.ui.max_bytes_per_row)) {
+            ui_update_deps(false);
+        }
+        if (igSliderInt("Bytes Per Slice", &state.ui.write.src.bytes_per_slice, state.ui.min_bytes_per_slice, state.ui.max_bytes_per_slice)) {
+            ui_update_deps(false);
+        }
+        igEndDisabled();
         igText("Write Destination:");
         if (igSliderInt("Mip Level", &state.ui.write.dst.mip_level, 0, IMG_NUM_MIPMAPS)) {
             ui_update_deps(false);

--- a/sapp/writeimage-sapp.glsl
+++ b/sapp/writeimage-sapp.glsl
@@ -1,0 +1,20 @@
+
+// vertex shader for a bufferless 'fullscreen triangle'
+@vs vs
+out vec2 uv;
+void main() {
+    float x = (gl_VertexIndex & 1) != 0 ? 2.0 : 0.0;
+    float y = (gl_VertexIndex & 2) != 0 ? 2.0 : 0.0;
+    gl_Position = vec4(vec2(x, y) * 2.0 - 1.0, 0.5, 1.0);
+    uv = vec2(x, 1.0 - y);
+}
+@end
+
+// FIXME
+@fs fs
+in vec2 uv;
+out vec4 frag_color;
+void main() {
+    frag_color = vec4(uv, 0.5f, 1.0f);
+}
+@end


### PR DESCRIPTION
See: https://github.com/floooh/sokol/pull/1554

- vertexindexbuffer-sapp: use 2x `sg_write_buffer_unsealed()` to populate combined vertex/index buffer